### PR TITLE
Implement website exclusion setting

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -4,13 +4,45 @@ import { initYouTubeFeatures } from './content/youtube.js';
 import { initHackerNewsFeatures } from './content/hackernews.js';
 import { initArticleFeatures } from './content/articles.js';
 
+// Check if current domain is excluded
+async function isDomainExcluded() {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get({
+      enableDomainExclusion: false,
+      excludedDomains: ''
+    }, (settings) => {
+      if (!settings.enableDomainExclusion) {
+        resolve(false);
+        return;
+      }
+      
+      const currentDomain = window.location.hostname;
+      const excludedDomains = settings.excludedDomains.split(',').map(d => d.trim()).filter(d => d);
+      
+      const isExcluded = excludedDomains.some(domain => {
+        // Check exact match or subdomain match
+        return currentDomain === domain || currentDomain.endsWith('.' + domain);
+      });
+      
+      resolve(isExcluded);
+    });
+  });
+}
+
 function isHNNewsPage() {
   if (!window.location.hostname.includes('ycombinator.com')) return false;
   const validPaths = ['/news','/newest','/front','/best','/ask','/show','/jobs'];
   return validPaths.includes(window.location.pathname);
 }
 
-function runInitForCurrentPage() {
+async function runInitForCurrentPage() {
+  // Check if domain is excluded
+  const excluded = await isDomainExcluded();
+  if (excluded) {
+    console.debug('[ExtractMD] Domain excluded, skipping initialization');
+    return;
+  }
+
   if (window.location.hostname.includes('youtube.com') && window.location.pathname.includes('/watch')) {
     console.debug('[ExtractMD] Initializing YouTube features');
     initYouTubeFeatures();
@@ -30,7 +62,7 @@ let lastUrl = window.location.href;
 const observer = new MutationObserver(() => {
   if (window.location.href !== lastUrl) {
     lastUrl = window.location.href;
-    setTimeout(runInitForCurrentPage, 500);
+    setTimeout(() => runInitForCurrentPage(), 500);
   }
 });
 observer.observe(document.body, { childList: true, subtree: true }); 

--- a/extension/content/utils.js
+++ b/extension/content/utils.js
@@ -8,7 +8,9 @@ export async function getSettings() {
       includeTimestamps: true,
       jumpToDomain: false,
       jumpToDomainUrl: 'https://chat.openai.com/',
-      closeTabAfterExtraction: false
+      closeTabAfterExtraction: false,
+      enableDomainExclusion: false,
+      excludedDomains: ''
     }, (settings) => {
       resolve(settings);
     });

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -7,7 +7,8 @@
     "activeTab",
     "storage",
     "clipboardWrite",
-    "scripting"
+    "scripting",
+    "tabs"
   ],
   "host_permissions": [
     "<all_urls>"

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -304,6 +304,20 @@
                     <span class="slider"></span>
                 </label>
             </div>
+            <div class="setting-item">
+                <span class="setting-label">Enable domain exclusion</span>
+                <label class="toggle-switch">
+                    <input type="checkbox" id="enableDomainExclusion">
+                    <span class="slider"></span>
+                </label>
+            </div>
+            <div class="setting-item" style="flex-direction:column;align-items:flex-start;gap:4px;">
+                <span class="setting-label" style="font-size:12px;">Excluded domains (comma separated)</span>
+                <input type="text" id="excludedDomains" placeholder="example.com, another-site.com">
+            </div>
+            <div class="setting-item">
+                <button id="addCurrentDomainBtn" class="action-button" style="width:100%;margin-top:8px;display:none;">Add current domain to exclusion list</button>
+            </div>
         </div>
     </div>
     <button class="collapsible"><img src="images/youtube.svg" class="section-icon" alt="YouTube"> <span>YouTube Transcript Settings</span></button>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add a general setting to exclude domains from extension functionality, allowing users to prevent the floating button and logic from appearing on specified websites.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f9ee135-e1f7-471e-8bcd-fdde740b6e3a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f9ee135-e1f7-471e-8bcd-fdde740b6e3a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>