### PR TITLE
fix: YouTube timestamp handling and page detection

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -27,14 +27,25 @@ async function runInitForCurrentPage() {
     return;
   }
 
-  if (window.location.hostname.includes('youtube.com') && window.location.pathname.includes('/watch')) {
+  const isYouTubeDomain = window.location.hostname.includes('youtube.com');
+  const isHNDomain = window.location.hostname.includes('ycombinator.com');
+
+  if (isYouTubeDomain && window.location.pathname.includes('/watch')) {
     console.debug('[ExtractMD] Initializing YouTube features');
     window.copyExtractMD = copyYouTubeTranscript;
     initYouTubeFeatures();
-  } else if (window.location.hostname.includes('ycombinator.com') && (window.location.pathname.startsWith('/item') || isHNNewsPage())) {
+  } else if (isHNDomain && (window.location.pathname.startsWith('/item') || isHNNewsPage())) {
     console.debug('[ExtractMD] Initializing Hacker News features');
     window.copyExtractMD = () => performHNCopy(false);
     initHackerNewsFeatures();
+  } else if (isYouTubeDomain || isHNDomain) {
+    // On YouTube/HN but not a supported page - do nothing, don't fall back to universal
+    console.debug('[ExtractMD] On YouTube/HN domain but not a supported page, skipping extraction');
+    window.copyExtractMD = null;
+    const existingButton = document.getElementById('extractmd-floating-button');
+    if (existingButton) {
+      existingButton.remove();
+    }
   } else {
     // Check for articles with substantial content
     const articles = document.querySelectorAll('article');

--- a/extension/content/youtube.js
+++ b/extension/content/youtube.js
@@ -87,7 +87,7 @@ async function waitForTranscriptAndCopy(settings = {}) {
     showNotification('❌ Transcript not found or not available for this video. Please check if the video has a transcript. If this persists, contact the developer.', 'error', true);
     throw new Error('Transcript failed to load within timeout period.');
   }
-  let transcriptText = extractTranscriptText();
+  let transcriptText = extractTranscriptText(settings.includeTimestamps !== false);
   let metaMd = '';
   if (settings.addTitleToTranscript || settings.addChannelToTranscript || settings.addUrlToTranscript) {
     let title = '';
@@ -130,7 +130,8 @@ async function waitForTranscriptAndCopy(settings = {}) {
                     return;
                 }
             }
-            copyToClipboard(transcriptText, userSettings.includeTimestamps);
+            // Timestamps already handled in extractTranscriptText, so pass true to avoid re-processing
+            copyToClipboard(transcriptText, true);
             showSuccessNotificationWithTokens('Transcript copied to clipboard!', transcriptText);
         }
     });
@@ -145,7 +146,7 @@ async function waitForTranscriptAndCopy(settings = {}) {
   }
 }
 
-function extractTranscriptText() {
+function extractTranscriptText(includeTimestamps = true) {
   const segments = document.querySelectorAll('ytd-transcript-segment-renderer');
   const sections = document.querySelectorAll('ytd-transcript-section-header-renderer');
   let transcript = '';
@@ -160,7 +161,7 @@ function extractTranscriptText() {
       const timestamp = element.querySelector('.segment-timestamp')?.textContent?.trim();
       const text = element.querySelector('.segment-text')?.textContent?.trim();
       if (text) {
-        if (timestamp) {
+        if (includeTimestamps && timestamp) {
           transcript += `[${timestamp}] ${text}\n`;
         } else {
           transcript += `${text}\n`;

--- a/tests/unit/content/youtube.test.js
+++ b/tests/unit/content/youtube.test.js
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+// We need to test extractTranscriptText which is not exported,
+// so we'll create a test version that mimics the function logic
+function extractTranscriptText(doc, includeTimestamps = true) {
+  let transcript = '';
+  const allElements = Array.from(doc.querySelectorAll('ytd-transcript-segment-renderer, ytd-transcript-section-header-renderer'));
+  allElements.forEach(element => {
+    if (element.tagName === 'YTD-TRANSCRIPT-SECTION-HEADER-RENDERER') {
+      const headerText = element.querySelector('.shelf-header-layout-wiz__title')?.textContent?.trim();
+      if (headerText) {
+        transcript += `\n\n## ${headerText}\n`;
+      }
+    } else if (element.tagName === 'YTD-TRANSCRIPT-SEGMENT-RENDERER') {
+      const timestamp = element.querySelector('.segment-timestamp')?.textContent?.trim();
+      const text = element.querySelector('.segment-text')?.textContent?.trim();
+      if (text) {
+        if (includeTimestamps && timestamp) {
+          transcript += `[${timestamp}] ${text}\n`;
+        } else {
+          transcript += `${text}\n`;
+        }
+      }
+    }
+  });
+  return transcript.trim();
+}
+
+describe('YouTube extractTranscriptText', () => {
+  let dom;
+  let document;
+
+  beforeEach(() => {
+    // Create a mock YouTube transcript DOM structure
+    dom = new JSDOM(`
+      <html>
+        <body>
+          <ytd-transcript-segment-renderer>
+            <div class="segment-timestamp">0:00</div>
+            <div class="segment-text">Hello and welcome</div>
+          </ytd-transcript-segment-renderer>
+          <ytd-transcript-segment-renderer>
+            <div class="segment-timestamp">0:05</div>
+            <div class="segment-text">to this video</div>
+          </ytd-transcript-segment-renderer>
+          <ytd-transcript-section-header-renderer>
+            <div class="shelf-header-layout-wiz__title">Chapter 1</div>
+          </ytd-transcript-section-header-renderer>
+          <ytd-transcript-segment-renderer>
+            <div class="segment-timestamp">1:30</div>
+            <div class="segment-text">Let's get started</div>
+          </ytd-transcript-segment-renderer>
+        </body>
+      </html>
+    `);
+    document = dom.window.document;
+  });
+
+  it('includes timestamps when includeTimestamps is true', () => {
+    const result = extractTranscriptText(document, true);
+    
+    expect(result).toContain('[0:00]');
+    expect(result).toContain('[0:05]');
+    expect(result).toContain('[1:30]');
+    expect(result).toContain('Hello and welcome');
+    expect(result).toContain('to this video');
+    expect(result).toContain('## Chapter 1');
+  });
+
+  it('excludes timestamps when includeTimestamps is false', () => {
+    const result = extractTranscriptText(document, false);
+    
+    expect(result).not.toContain('[0:00]');
+    expect(result).not.toContain('[0:05]');
+    expect(result).not.toContain('[1:30]');
+    expect(result).toContain('Hello and welcome');
+    expect(result).toContain('to this video');
+    expect(result).toContain('## Chapter 1');
+  });
+
+  it('defaults to including timestamps when parameter is omitted', () => {
+    const result = extractTranscriptText(document);
+    
+    expect(result).toContain('[0:00]');
+    expect(result).toContain('[0:05]');
+  });
+
+  it('handles segments without timestamps', () => {
+    const domNoTimestamp = new JSDOM(`
+      <html>
+        <body>
+          <ytd-transcript-segment-renderer>
+            <div class="segment-text">Text without timestamp</div>
+          </ytd-transcript-segment-renderer>
+        </body>
+      </html>
+    `);
+    
+    const result = extractTranscriptText(domNoTimestamp.window.document, true);
+    expect(result).toBe('Text without timestamp');
+    expect(result).not.toContain('[');
+  });
+
+  it('preserves section headers regardless of timestamp setting', () => {
+    const resultWithTimestamps = extractTranscriptText(document, true);
+    const resultWithoutTimestamps = extractTranscriptText(document, false);
+    
+    expect(resultWithTimestamps).toContain('## Chapter 1');
+    expect(resultWithoutTimestamps).toContain('## Chapter 1');
+  });
+});
+


### PR DESCRIPTION
Fixes YouTube transcript timestamp option and prevents incorrect fallback to universal extractor on unsupported YouTube/HN pages.

## Changes

- **YouTube timestamps**: `extractTranscriptText` now respects the `includeTimestamps` setting properly
- **Page detection**: YouTube/HN domains on non-supported pages (e.g., YouTube homepage, HN main page) no longer incorrectly fall back to the universal article extractor
- **Tests**: Added unit tests for YouTube transcript extraction

## Benefits

- Users who disable timestamps will now correctly get transcripts without timestamps
- Prevents confusing behavior where the floating button appears on unsupported YouTube/HN pages