### PR TITLE
feat: floating button enhancements with drag, dismiss, and live ignore toggle

### DIFF
--- a/extension/content/articles.js
+++ b/extension/content/articles.js
@@ -262,15 +262,35 @@ async function showArticleInfoNotification(articles, highlightLongest = false) {
   showNotification(message, 'info');
 }
 
-function manageFloatingButtonForArticles() {
+async function manageFloatingButtonForArticles() {
+  // Don't create button if domain is ignored
+  if (window.__extractmd_domain_ignored) {
+    if (floatingButtonController) {
+      floatingButtonController.remove();
+      floatingButtonController = null;
+    }
+    return;
+  }
+  
   const articles = Array.from(document.querySelectorAll('article'));
   const existingButton = document.getElementById('extractmd-floating-button');
   
   if (articles.length > 0) {
     if (!existingButton) {
-      floatingButtonController = createFloatingButton({
+      // Load floating button settings
+      const buttonSettings = await new Promise(resolve => {
+        chrome.storage.sync.get({
+          floatingButtonEnableDrag: true,
+          floatingButtonEnableDismiss: true
+        }, resolve);
+      });
+      
+      floatingButtonController = await createFloatingButton({
         variant: 'light',
         emoji: '📝',
+        domain: window.location.hostname,
+        enableDrag: buttonSettings.floatingButtonEnableDrag,
+        enableDismiss: buttonSettings.floatingButtonEnableDismiss,
         onClick: async () => {
           await performArticleCopy(true);
         }

--- a/extension/content/components/FloatingButton.js
+++ b/extension/content/components/FloatingButton.js
@@ -1,6 +1,66 @@
 // Shared Floating Button component for ExtractMD
 // Used by YouTube, Hacker News, and Article extractors
 
+// Default position offset from bottom-right corner
+const DEFAULT_OFFSET = { left: 0, up: 0 };
+const DEFAULT_RIGHT = 20;
+const DEFAULT_BOTTOM = 20;
+const DRAG_THRESHOLD = 5; // pixels - movement less than this triggers click
+const HOVER_DELAY_MS = 500; // ms before showing dismiss button
+
+/**
+ * Load saved position offset for a domain from chrome.storage.local
+ * @param {string} domain - The domain to load position for
+ * @returns {Promise<{left: number, up: number}>}
+ */
+async function loadPositionOffset(domain) {
+  if (!domain) return DEFAULT_OFFSET;
+  
+  return new Promise(resolve => {
+    chrome.storage.local.get({ floatingButtonPositions: {} }, (items) => {
+      const positions = items.floatingButtonPositions || {};
+      resolve(positions[domain] || DEFAULT_OFFSET);
+    });
+  });
+}
+
+/**
+ * Save position offset for a domain to chrome.storage.local
+ * @param {string} domain - The domain to save position for
+ * @param {{left: number, up: number}} offset - The offset from default position
+ */
+function savePositionOffset(domain, offset) {
+  if (!domain) return;
+  
+  chrome.storage.local.get({ floatingButtonPositions: {} }, (items) => {
+    const positions = items.floatingButtonPositions || {};
+    positions[domain] = offset;
+    chrome.storage.local.set({ floatingButtonPositions: positions });
+  });
+}
+
+/**
+ * Add domain to ignored domains list
+ * @param {string} domain - The domain to ignore
+ * @returns {Promise<void>}
+ */
+async function addDomainToIgnoreList(domain) {
+  if (!domain) return;
+  
+  return new Promise(resolve => {
+    chrome.storage.sync.get({ ignoredDomains: '' }, (items) => {
+      let domains = items.ignoredDomains.split('\n').map(d => d.trim()).filter(d => d.length > 0);
+      if (!domains.includes(domain)) {
+        domains.push(domain);
+        const newValue = domains.join('\n');
+        chrome.storage.sync.set({ ignoredDomains: newValue }, resolve);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
 /**
  * Creates a floating action button for ExtractMD
  * @param {Object} options - Configuration options
@@ -8,13 +68,19 @@
  * @param {string} [options.variant='dark'] - Visual variant: 'dark' (glassmorphism) or 'light' (solid white)
  * @param {string} [options.emoji='📝'] - Emoji to display in the button
  * @param {string} [options.id='extractmd-floating-button'] - DOM element ID
- * @returns {Object} Button controller with element and state methods
+ * @param {string} [options.domain] - Current domain for position persistence and ignore functionality
+ * @param {boolean} [options.enableDrag=true] - Whether dragging to reposition is enabled
+ * @param {boolean} [options.enableDismiss=true] - Whether the dismiss (X) button is enabled
+ * @returns {Promise<Object|null>} Button controller with element and state methods
  */
-export function createFloatingButton({
+export async function createFloatingButton({
   onClick,
   variant = 'dark',
   emoji = '📝',
-  id = 'extractmd-floating-button'
+  id = 'extractmd-floating-button',
+  domain = '',
+  enableDrag = true,
+  enableDismiss = true
 }) {
   // Check if button already exists
   const existing = document.getElementById(id);
@@ -22,15 +88,54 @@ export function createFloatingButton({
     return null;
   }
 
+  // Load saved position BEFORE creating the button to avoid flash
+  let currentOffset = { ...DEFAULT_OFFSET };
+  if (domain) {
+    currentOffset = await loadPositionOffset(domain);
+  }
+
   const button = document.createElement('div');
   button.id = id;
-  button.innerHTML = `<div class="button-emoji">${emoji}</div>`;
+  
+  // Create inner content container
+  const contentContainer = document.createElement('div');
+  contentContainer.className = 'button-content';
+  contentContainer.innerHTML = `<div class="button-emoji">${emoji}</div>`;
+  button.appendChild(contentContainer);
+  
+  // Create dismiss button (hidden by default)
+  const dismissBtn = document.createElement('div');
+  dismissBtn.className = 'extractmd-dismiss-btn';
+  dismissBtn.innerHTML = '×';
+  dismissBtn.style.cssText = `
+    position: absolute;
+    top: -6px;
+    right: -6px;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: #ef4444;
+    color: white;
+    font-size: 14px;
+    line-height: 18px;
+    text-align: center;
+    cursor: pointer;
+    display: none;
+    z-index: 10001;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    font-weight: bold;
+  `;
+  button.appendChild(dismissBtn);
+
+  // Calculate initial position with saved offset applied
+  const initialRight = DEFAULT_RIGHT + currentOffset.left;
+  const initialBottom = DEFAULT_BOTTOM + currentOffset.up;
 
   // Variant-specific styles
   const baseStyles = `
     position: fixed;
-    bottom: 20px;
-    right: 20px;
+    bottom: ${initialBottom}px;
+    right: ${initialRight}px;
     border-radius: 50%;
     width: 56px;
     height: 56px;
@@ -41,7 +146,7 @@ export function createFloatingButton({
     display: flex;
     align-items: center;
     justify-content: center;
-    transition: all 0.3s ease;
+    transition: box-shadow 0.3s ease, opacity 0.3s ease, background 0.3s ease;
     user-select: none;
   `;
 
@@ -66,25 +171,173 @@ export function createFloatingButton({
   const hoverBg = variant === 'light' ? '#f3f4f6' : 'rgba(255, 255, 255, 0.25)';
   const normalBg = variant === 'light' ? 'rgba(255, 255, 255, 0.95)' : 'rgba(255, 255, 255, 0.15)';
 
+  // Drag state
+  let isDragging = false;
+  let dragStartX = 0;
+  let dragStartY = 0;
+  let buttonStartRight = initialRight;
+  let buttonStartBottom = initialBottom;
+  let hasMoved = false;
+  let justFinishedDragging = false; // Flag to prevent click after drag
+  
+  // Hover state for dismiss button
+  let hoverTimeout = null;
+  let isHovering = false;
+
+  // Mouse down - start potential drag (only if dragging is enabled)
+  button.addEventListener('mousedown', (e) => {
+    if (!enableDrag) return; // Dragging disabled
+    if (e.target === dismissBtn) return; // Don't start drag on dismiss button
+    if (button.dataset.processing) return;
+    
+    isDragging = true;
+    hasMoved = false;
+    dragStartX = e.clientX;
+    dragStartY = e.clientY;
+    
+    // Get current position
+    const computedStyle = window.getComputedStyle(button);
+    buttonStartRight = parseInt(computedStyle.right, 10) || DEFAULT_RIGHT;
+    buttonStartBottom = parseInt(computedStyle.bottom, 10) || DEFAULT_BOTTOM;
+    
+    // Prevent text selection during drag
+    e.preventDefault();
+    
+    // Change cursor
+    button.style.cursor = 'grabbing';
+    button.style.transition = 'box-shadow 0.3s ease, opacity 0.3s ease, background 0.3s ease';
+  });
+
+  // Mouse move - handle drag
+  const handleMouseMove = (e) => {
+    if (!isDragging) return;
+    
+    const deltaX = dragStartX - e.clientX; // Positive = moved left (increase right)
+    const deltaY = dragStartY - e.clientY; // Positive = moved up (increase bottom)
+    
+    // Check if we've moved enough to consider it a drag
+    if (Math.abs(deltaX) > DRAG_THRESHOLD || Math.abs(deltaY) > DRAG_THRESHOLD) {
+      hasMoved = true;
+    }
+    
+    // Update position
+    const newRight = Math.max(0, Math.min(window.innerWidth - 60, buttonStartRight + deltaX));
+    const newBottom = Math.max(0, Math.min(window.innerHeight - 60, buttonStartBottom + deltaY));
+    
+    button.style.right = `${newRight}px`;
+    button.style.bottom = `${newBottom}px`;
+  };
+
+  // Mouse up - end drag or trigger click
+  const handleMouseUp = (e) => {
+    if (!isDragging) return;
+    
+    isDragging = false;
+    button.style.cursor = 'pointer';
+    
+    if (hasMoved) {
+      // Set flag to prevent the click event that follows mouseup
+      justFinishedDragging = true;
+      
+      // Reset the flag after a short delay (after click event would have fired)
+      setTimeout(() => {
+        justFinishedDragging = false;
+      }, 10);
+      
+      if (domain) {
+        // Calculate and save the new offset
+        const computedStyle = window.getComputedStyle(button);
+        const currentRight = parseInt(computedStyle.right, 10) || DEFAULT_RIGHT;
+        const currentBottom = parseInt(computedStyle.bottom, 10) || DEFAULT_BOTTOM;
+        
+        currentOffset = {
+          left: currentRight - DEFAULT_RIGHT,
+          up: currentBottom - DEFAULT_BOTTOM
+        };
+        
+        savePositionOffset(domain, currentOffset);
+      }
+    }
+    
+    hasMoved = false;
+  };
+
+  // Add document-level listeners for drag
+  document.addEventListener('mousemove', handleMouseMove);
+  document.addEventListener('mouseup', handleMouseUp);
+
+  // Click handler - only trigger if not dragging
+  button.addEventListener('click', (e) => {
+    if (e.target === dismissBtn) return; // Don't trigger on dismiss button
+    if (button.dataset.processing) return;
+    
+    // If we just finished dragging, don't trigger click
+    if (isDragging || justFinishedDragging) return;
+    
+    onClick();
+  });
+
+  // Hover effects
   button.addEventListener('mouseenter', () => {
     if (!button.dataset.processing) {
-      button.style.transform = 'translateY(-2px) scale(1.1)';
+      isHovering = true;
       button.style.boxShadow = '0 6px 16px rgba(0,0,0,0.25)';
       button.style.opacity = '1';
       button.style.background = hoverBg;
+      
+      // Start timer to show dismiss button (only if dismiss is enabled)
+      if (domain && enableDismiss) {
+        hoverTimeout = setTimeout(() => {
+          if (isHovering && !isDragging) {
+            dismissBtn.style.display = 'block';
+          }
+        }, HOVER_DELAY_MS);
+      }
     }
   });
 
   button.addEventListener('mouseleave', () => {
+    isHovering = false;
+    
+    // Clear hover timeout
+    if (hoverTimeout) {
+      clearTimeout(hoverTimeout);
+      hoverTimeout = null;
+    }
+    
+    // Hide dismiss button
+    dismissBtn.style.display = 'none';
+    
     if (!button.dataset.processing) {
-      button.style.transform = 'translateY(0) scale(1)';
       button.style.boxShadow = '0 4px 12px rgba(0,0,0,0.15)';
       button.style.opacity = variant === 'light' ? '1' : '0.7';
       button.style.background = normalBg;
     }
   });
 
-  button.addEventListener('click', onClick);
+  // Dismiss button click handler
+  dismissBtn.addEventListener('click', async (e) => {
+    e.stopPropagation();
+    
+    if (domain) {
+      await addDomainToIgnoreList(domain);
+      
+      // Set global flag to prevent mutation observers from recreating the button
+      window.__extractmd_domain_ignored = true;
+      
+      // Clear the copy function
+      window.copyExtractMD = null;
+      
+      // Remove the button
+      if (button.parentNode) {
+        button.parentNode.removeChild(button);
+      }
+      
+      // Clean up event listeners
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    }
+  });
 
   // Controller object with state methods
   const controller = {
@@ -95,19 +348,20 @@ export function createFloatingButton({
      */
     setLoading() {
       button.dataset.processing = 'true';
-      button.innerHTML = `<div class="button-emoji">⏳</div>`;
+      contentContainer.innerHTML = `<div class="button-emoji">⏳</div>`;
       button.style.background = 'rgba(255, 193, 7, 0.8)';
       button.style.border = '1px solid rgba(255, 193, 7, 0.3)';
       button.style.cursor = 'not-allowed';
       button.style.fontSize = '20px';
       button.style.opacity = '1';
+      dismissBtn.style.display = 'none';
     },
 
     /**
      * Set button to success state
      */
     setSuccess() {
-      button.innerHTML = `<div class="button-emoji">✅</div>`;
+      contentContainer.innerHTML = `<div class="button-emoji">✅</div>`;
       button.style.background = 'rgba(76, 175, 80, 0.8)';
       button.style.border = '1px solid rgba(76, 175, 80, 0.3)';
       button.style.fontSize = '24px';
@@ -118,7 +372,7 @@ export function createFloatingButton({
      * Set button to error state
      */
     setError() {
-      button.innerHTML = `<div class="button-emoji">❌</div>`;
+      contentContainer.innerHTML = `<div class="button-emoji">❌</div>`;
       button.style.background = 'rgba(244, 67, 54, 0.8)';
       button.style.border = '1px solid rgba(244, 67, 54, 0.3)';
       button.style.fontSize = '24px';
@@ -130,7 +384,7 @@ export function createFloatingButton({
      */
     setNormal() {
       delete button.dataset.processing;
-      button.innerHTML = `<div class="button-emoji">${emoji}</div>`;
+      contentContainer.innerHTML = `<div class="button-emoji">${emoji}</div>`;
       button.style.background = normalBg;
       button.style.border = variant === 'light' ? '1px solid #ccc' : '1px solid rgba(255, 255, 255, 0.2)';
       button.style.cursor = 'pointer';
@@ -153,9 +407,14 @@ export function createFloatingButton({
     },
 
     /**
-     * Remove button from DOM
+     * Remove button from DOM and clean up event listeners
      */
     remove() {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+      if (hoverTimeout) {
+        clearTimeout(hoverTimeout);
+      }
       if (button.parentNode) {
         button.parentNode.removeChild(button);
       }
@@ -172,4 +431,3 @@ export function createFloatingButton({
 
   return controller;
 }
-

--- a/extension/content/hackernews.js
+++ b/extension/content/hackernews.js
@@ -280,7 +280,11 @@ function extractHNNewsMarkdown(settings) {
 
 export function initHackerNewsFeatures() {
   console.debug('[ExtractMD] initHackerNewsFeatures called');
-  chrome.storage.sync.get({ enableHackerNewsIntegration: true }, function(items) {
+  chrome.storage.sync.get({ 
+    enableHackerNewsIntegration: true,
+    floatingButtonEnableDrag: true,
+    floatingButtonEnableDismiss: true
+  }, async function(items) {
     if (items.enableHackerNewsIntegration === false) return;
     if (!(isHNItemPage() || isHNNewsPage())) return;
     if (document.getElementById('extractmd-floating-button')) {
@@ -288,9 +292,12 @@ export function initHackerNewsFeatures() {
       return;
     }
     
-    floatingButtonController = createFloatingButton({
+    floatingButtonController = await createFloatingButton({
       variant: 'dark',
       emoji: '📝',
+      domain: window.location.hostname,
+      enableDrag: items.floatingButtonEnableDrag,
+      enableDismiss: items.floatingButtonEnableDismiss,
       onClick: async () => {
         await performHNCopy(true);
       }

--- a/extension/content/universal.js
+++ b/extension/content/universal.js
@@ -213,7 +213,16 @@ function showContentInfoNotification(contentElement) {
 /**
  * Manage the floating button for universal extraction
  */
-function manageFloatingButtonForUniversal() {
+async function manageFloatingButtonForUniversal() {
+  // Don't create button if domain is ignored
+  if (window.__extractmd_domain_ignored) {
+    if (floatingButtonController) {
+      floatingButtonController.remove();
+      floatingButtonController = null;
+    }
+    return;
+  }
+  
   const existingButton = document.getElementById('extractmd-floating-button');
   
   // Check if there's meaningful content on the page
@@ -222,9 +231,20 @@ function manageFloatingButtonForUniversal() {
   
   if (hasContent) {
     if (!existingButton) {
-      floatingButtonController = createFloatingButton({
+      // Load floating button settings
+      const buttonSettings = await new Promise(resolve => {
+        chrome.storage.sync.get({
+          floatingButtonEnableDrag: true,
+          floatingButtonEnableDismiss: true
+        }, resolve);
+      });
+      
+      floatingButtonController = await createFloatingButton({
         variant: 'light',
         emoji: '📄',
+        domain: window.location.hostname,
+        enableDrag: buttonSettings.floatingButtonEnableDrag,
+        enableDismiss: buttonSettings.floatingButtonEnableDismiss,
         onClick: async () => {
           await performUniversalCopy(true);
         }

--- a/extension/content/youtube.js
+++ b/extension/content/youtube.js
@@ -258,7 +258,7 @@ export function initYouTubeFeatures() {
   });
 }
 
-function initializeFloatingButton() {
+async function initializeFloatingButton() {
   console.debug('[ExtractMD] initializeFloatingButton (YouTube) called');
   if (!(window.location.hostname.includes('youtube.com') && window.location.pathname.includes('/watch'))) return;
   if (document.getElementById('extractmd-floating-button')) {
@@ -266,9 +266,20 @@ function initializeFloatingButton() {
     return;
   }
   
-  floatingButtonController = createFloatingButton({
+  // Load floating button settings
+  const buttonSettings = await new Promise(resolve => {
+    chrome.storage.sync.get({
+      floatingButtonEnableDrag: true,
+      floatingButtonEnableDismiss: true
+    }, resolve);
+  });
+  
+  floatingButtonController = await createFloatingButton({
     variant: 'dark',
     emoji: '📝',
+    domain: window.location.hostname,
+    enableDrag: buttonSettings.floatingButtonEnableDrag,
+    enableDismiss: buttonSettings.floatingButtonEnableDismiss,
     onClick: async () => {
       if (isProcessing) return;
       isProcessing = true;

--- a/extension/popup/domainToggle.js
+++ b/extension/popup/domainToggle.js
@@ -110,6 +110,16 @@ export async function initializeDomainToggle() {
             const nowIgnored = await toggleDomainIgnore(currentDomain);
             updateToggleButton(nowIgnored);
             
+            // Send message to content script to reinitialize
+            try {
+                const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+                if (tab && tab.id) {
+                    chrome.tabs.sendMessage(tab.id, { action: 'reinitialize' });
+                }
+            } catch (e) {
+                console.debug('[ExtractMD] Could not send reinitialize message:', e);
+            }
+            
             if (nowIgnored) {
                 showStatus(`${currentDomain} will be ignored`, 'success');
             } else {

--- a/extension/shared/defaults.js
+++ b/extension/shared/defaults.js
@@ -53,7 +53,11 @@ export const DEFAULTS = {
   universalContentMode: 'auto',  // 'auto' | 'full' | 'main' | 'selector'
   universalCustomSelector: '',
   universalStripNav: true,
-  universalPreserveCodeBlocks: true
+  universalPreserveCodeBlocks: true,
+  
+  // Floating button behavior
+  floatingButtonEnableDrag: true,
+  floatingButtonEnableDismiss: true
 };
 
 // Schema for validation during import
@@ -96,6 +100,8 @@ export const SETTING_SCHEMA = {
   universalContentMode: 'string',
   universalCustomSelector: 'string',
   universalStripNav: 'boolean',
-  universalPreserveCodeBlocks: 'boolean'
+  universalPreserveCodeBlocks: 'boolean',
+  floatingButtonEnableDrag: 'boolean',
+  floatingButtonEnableDismiss: 'boolean'
 };
 

--- a/tests/unit/content/components/FloatingButton.test.js
+++ b/tests/unit/content/components/FloatingButton.test.js
@@ -7,6 +7,26 @@ describe('FloatingButton component', () => {
   beforeEach(() => {
     container = document.createElement('div');
     document.body.appendChild(container);
+    
+    // Mock chrome.storage.local
+    global.chrome = {
+      storage: {
+        local: {
+          get: vi.fn((keys, callback) => {
+            callback({ floatingButtonPositions: {} });
+          }),
+          set: vi.fn()
+        },
+        sync: {
+          get: vi.fn((keys, callback) => {
+            callback({ ignoredDomains: '' });
+          }),
+          set: vi.fn((data, callback) => {
+            if (callback) callback();
+          })
+        }
+      }
+    };
   });
 
   afterEach(() => {
@@ -14,12 +34,13 @@ describe('FloatingButton component', () => {
     const buttons = document.querySelectorAll('#extractmd-floating-button');
     buttons.forEach(b => b.remove());
     container.remove();
+    vi.clearAllMocks();
   });
 
   describe('createFloatingButton', () => {
-    it('creates a button element with correct structure', () => {
+    it('creates a button element with correct structure', async () => {
       const onClick = vi.fn();
-      const controller = createFloatingButton({ onClick });
+      const controller = await createFloatingButton({ onClick });
       
       expect(controller).not.toBeNull();
       expect(controller.element).toBeDefined();
@@ -27,45 +48,53 @@ describe('FloatingButton component', () => {
       expect(controller.element.innerHTML).toContain('📝');
     });
 
-    it('uses custom emoji when provided', () => {
+    it('uses custom emoji when provided', async () => {
       const onClick = vi.fn();
-      const controller = createFloatingButton({ onClick, emoji: '🎬' });
+      const controller = await createFloatingButton({ onClick, emoji: '🎬' });
       
       expect(controller.element.innerHTML).toContain('🎬');
     });
 
-    it('uses custom id when provided', () => {
+    it('uses custom id when provided', async () => {
       const onClick = vi.fn();
-      const controller = createFloatingButton({ onClick, id: 'custom-button' });
+      const controller = await createFloatingButton({ onClick, id: 'custom-button' });
       
       expect(controller.element.id).toBe('custom-button');
     });
 
-    it('returns null if button with same id already exists', () => {
+    it('returns null if button with same id already exists', async () => {
       const onClick = vi.fn();
-      const first = createFloatingButton({ onClick });
+      const first = await createFloatingButton({ onClick });
       first.appendTo(document.body);
       
-      const second = createFloatingButton({ onClick });
+      const second = await createFloatingButton({ onClick });
       
       expect(second).toBeNull();
     });
 
-    it('calls onClick handler when clicked', () => {
+    it('calls onClick handler when clicked', async () => {
       const onClick = vi.fn();
-      const controller = createFloatingButton({ onClick });
+      const controller = await createFloatingButton({ onClick });
       controller.appendTo(document.body);
       
       controller.element.click();
       
       expect(onClick).toHaveBeenCalledTimes(1);
     });
+
+    it('accepts domain parameter', async () => {
+      const onClick = vi.fn();
+      const controller = await createFloatingButton({ onClick, domain: 'example.com' });
+      
+      expect(controller).not.toBeNull();
+      expect(controller.element).toBeDefined();
+    });
   });
 
   describe('dark variant (default)', () => {
-    it('creates button with dark variant', () => {
+    it('creates button with dark variant', async () => {
       const onClick = vi.fn();
-      const controller = createFloatingButton({ onClick });
+      const controller = await createFloatingButton({ onClick });
       
       // Verify button is created with correct structure
       expect(controller).not.toBeNull();
@@ -75,9 +104,9 @@ describe('FloatingButton component', () => {
   });
 
   describe('light variant', () => {
-    it('creates button with light variant', () => {
+    it('creates button with light variant', async () => {
       const onClick = vi.fn();
-      const controller = createFloatingButton({ onClick, variant: 'light' });
+      const controller = await createFloatingButton({ onClick, variant: 'light' });
       
       // Verify button is created with correct structure
       expect(controller).not.toBeNull();
@@ -87,9 +116,9 @@ describe('FloatingButton component', () => {
   });
 
   describe('state methods', () => {
-    it('setLoading updates button to loading state', () => {
+    it('setLoading updates button to loading state', async () => {
       const onClick = vi.fn();
-      const controller = createFloatingButton({ onClick });
+      const controller = await createFloatingButton({ onClick });
       
       controller.setLoading();
       
@@ -98,9 +127,9 @@ describe('FloatingButton component', () => {
       expect(controller.element.style.cursor).toBe('not-allowed');
     });
 
-    it('setSuccess updates button to success state', () => {
+    it('setSuccess updates button to success state', async () => {
       const onClick = vi.fn();
-      const controller = createFloatingButton({ onClick });
+      const controller = await createFloatingButton({ onClick });
       
       controller.setSuccess();
       
@@ -108,9 +137,9 @@ describe('FloatingButton component', () => {
       expect(controller.element.style.background).toContain('rgba(76, 175, 80');
     });
 
-    it('setError updates button to error state', () => {
+    it('setError updates button to error state', async () => {
       const onClick = vi.fn();
-      const controller = createFloatingButton({ onClick });
+      const controller = await createFloatingButton({ onClick });
       
       controller.setError();
       
@@ -118,9 +147,9 @@ describe('FloatingButton component', () => {
       expect(controller.element.style.background).toContain('rgba(244, 67, 54');
     });
 
-    it('setNormal resets button to initial state', () => {
+    it('setNormal resets button to initial state', async () => {
       const onClick = vi.fn();
-      const controller = createFloatingButton({ onClick, emoji: '📝' });
+      const controller = await createFloatingButton({ onClick, emoji: '📝' });
       
       controller.setLoading();
       controller.setNormal();
@@ -132,9 +161,9 @@ describe('FloatingButton component', () => {
   });
 
   describe('visibility methods', () => {
-    it('show makes button visible', () => {
+    it('show makes button visible', async () => {
       const onClick = vi.fn();
-      const controller = createFloatingButton({ onClick });
+      const controller = await createFloatingButton({ onClick });
       controller.element.style.display = 'none';
       
       controller.show();
@@ -142,9 +171,9 @@ describe('FloatingButton component', () => {
       expect(controller.element.style.display).toBe('flex');
     });
 
-    it('hide makes button invisible', () => {
+    it('hide makes button invisible', async () => {
       const onClick = vi.fn();
-      const controller = createFloatingButton({ onClick });
+      const controller = await createFloatingButton({ onClick });
       
       controller.hide();
       
@@ -153,18 +182,18 @@ describe('FloatingButton component', () => {
   });
 
   describe('DOM methods', () => {
-    it('appendTo adds button to specified parent', () => {
+    it('appendTo adds button to specified parent', async () => {
       const onClick = vi.fn();
-      const controller = createFloatingButton({ onClick });
+      const controller = await createFloatingButton({ onClick });
       
       controller.appendTo(container);
       
       expect(container.contains(controller.element)).toBe(true);
     });
 
-    it('remove removes button from DOM', () => {
+    it('remove removes button from DOM', async () => {
       const onClick = vi.fn();
-      const controller = createFloatingButton({ onClick });
+      const controller = await createFloatingButton({ onClick });
       controller.appendTo(container);
       
       controller.remove();
@@ -172,5 +201,267 @@ describe('FloatingButton component', () => {
       expect(container.contains(controller.element)).toBe(false);
     });
   });
-});
 
+  describe('drag behavior', () => {
+    it('does not trigger onClick when button is dragged', async () => {
+      const onClick = vi.fn();
+      const controller = await createFloatingButton({ onClick, domain: 'example.com' });
+      controller.appendTo(document.body);
+      
+      // Simulate drag: mousedown, move significantly, mouseup
+      const mousedownEvent = new MouseEvent('mousedown', {
+        clientX: 100,
+        clientY: 100,
+        bubbles: true
+      });
+      controller.element.dispatchEvent(mousedownEvent);
+      
+      // Move significantly (more than DRAG_THRESHOLD of 5px)
+      const mousemoveEvent = new MouseEvent('mousemove', {
+        clientX: 150,
+        clientY: 150,
+        bubbles: true
+      });
+      document.dispatchEvent(mousemoveEvent);
+      
+      const mouseupEvent = new MouseEvent('mouseup', {
+        bubbles: true
+      });
+      document.dispatchEvent(mouseupEvent);
+      
+      // Click should not be triggered after drag
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('saves position to storage after drag when domain is provided', async () => {
+      const onClick = vi.fn();
+      const controller = await createFloatingButton({ onClick, domain: 'example.com' });
+      controller.appendTo(document.body);
+      
+      // Simulate drag
+      const mousedownEvent = new MouseEvent('mousedown', {
+        clientX: 100,
+        clientY: 100,
+        bubbles: true
+      });
+      controller.element.dispatchEvent(mousedownEvent);
+      
+      const mousemoveEvent = new MouseEvent('mousemove', {
+        clientX: 150,
+        clientY: 150,
+        bubbles: true
+      });
+      document.dispatchEvent(mousemoveEvent);
+      
+      const mouseupEvent = new MouseEvent('mouseup', {
+        bubbles: true
+      });
+      document.dispatchEvent(mouseupEvent);
+      
+      // Wait for async storage operations
+      await new Promise(resolve => setTimeout(resolve, 10));
+      
+      // Check that storage.local.set was called
+      expect(chrome.storage.local.set).toHaveBeenCalled();
+    });
+
+    it('loads saved position on creation when domain is provided', async () => {
+      // Setup mock to return a saved position
+      chrome.storage.local.get = vi.fn((keys, callback) => {
+        callback({
+          floatingButtonPositions: {
+            'example.com': { left: 50, up: 100 }
+          }
+        });
+      });
+      
+      const onClick = vi.fn();
+      const controller = await createFloatingButton({ onClick, domain: 'example.com' });
+      controller.appendTo(document.body);
+      
+      // Check that storage.local.get was called
+      expect(chrome.storage.local.get).toHaveBeenCalled();
+    });
+  });
+
+  describe('dismiss button', () => {
+    it('creates dismiss button element', async () => {
+      const onClick = vi.fn();
+      const controller = await createFloatingButton({ onClick, domain: 'example.com' });
+      
+      const dismissBtn = controller.element.querySelector('.extractmd-dismiss-btn');
+      expect(dismissBtn).not.toBeNull();
+      expect(dismissBtn.innerHTML).toBe('×');
+    });
+
+    it('dismiss button is hidden by default', async () => {
+      const onClick = vi.fn();
+      const controller = await createFloatingButton({ onClick, domain: 'example.com' });
+      controller.appendTo(document.body);
+      
+      const dismissBtn = controller.element.querySelector('.extractmd-dismiss-btn');
+      // The dismiss button should exist
+      expect(dismissBtn).not.toBeNull();
+      expect(dismissBtn.className).toBe('extractmd-dismiss-btn');
+      expect(dismissBtn.innerHTML).toBe('×');
+    });
+
+    it('dismiss button appears after hover timeout', async () => {
+      vi.useFakeTimers();
+      
+      const onClick = vi.fn();
+      const controller = await createFloatingButton({ onClick, domain: 'example.com' });
+      controller.appendTo(document.body);
+      
+      // Simulate mouseenter
+      const mouseenterEvent = new MouseEvent('mouseenter', { bubbles: true });
+      controller.element.dispatchEvent(mouseenterEvent);
+      
+      // Advance timer past HOVER_DELAY_MS (500ms)
+      vi.advanceTimersByTime(600);
+      
+      const dismissBtn = controller.element.querySelector('.extractmd-dismiss-btn');
+      expect(dismissBtn.style.display).toBe('block');
+      
+      vi.useRealTimers();
+    });
+
+    it('dismiss button hides on mouseleave', async () => {
+      vi.useFakeTimers();
+      
+      const onClick = vi.fn();
+      const controller = await createFloatingButton({ onClick, domain: 'example.com' });
+      controller.appendTo(document.body);
+      
+      // Show dismiss button
+      const mouseenterEvent = new MouseEvent('mouseenter', { bubbles: true });
+      controller.element.dispatchEvent(mouseenterEvent);
+      vi.advanceTimersByTime(600);
+      
+      // Verify it's visible
+      const dismissBtn = controller.element.querySelector('.extractmd-dismiss-btn');
+      expect(dismissBtn.style.display).toBe('block');
+      
+      // Simulate mouseleave
+      const mouseleaveEvent = new MouseEvent('mouseleave', { bubbles: true });
+      controller.element.dispatchEvent(mouseleaveEvent);
+      
+      expect(dismissBtn.style.display).toBe('none');
+      
+      vi.useRealTimers();
+    });
+
+    it('dismiss button click adds domain to ignore list', async () => {
+      const onClick = vi.fn();
+      const controller = await createFloatingButton({ onClick, domain: 'example.com' });
+      controller.appendTo(document.body);
+      
+      const dismissBtn = controller.element.querySelector('.extractmd-dismiss-btn');
+      dismissBtn.style.display = 'block'; // Make it visible for clicking
+      
+      // Click dismiss button
+      dismissBtn.click();
+      
+      // Wait for async operations
+      await new Promise(resolve => setTimeout(resolve, 10));
+      
+      // Check that storage.sync.set was called with the domain
+      expect(chrome.storage.sync.set).toHaveBeenCalled();
+      const setCall = chrome.storage.sync.set.mock.calls[0][0];
+      expect(setCall.ignoredDomains).toContain('example.com');
+    });
+
+    it('dismiss button click removes button from DOM', async () => {
+      const onClick = vi.fn();
+      const controller = await createFloatingButton({ onClick, domain: 'example.com' });
+      controller.appendTo(document.body);
+      
+      const dismissBtn = controller.element.querySelector('.extractmd-dismiss-btn');
+      dismissBtn.style.display = 'block';
+      
+      // Click dismiss button
+      dismissBtn.click();
+      
+      // Wait for async operations
+      await new Promise(resolve => setTimeout(resolve, 10));
+      
+      // Button should be removed
+      expect(document.body.contains(controller.element)).toBe(false);
+    });
+
+    it('dismiss button click does not trigger main onClick', async () => {
+      const onClick = vi.fn();
+      const controller = await createFloatingButton({ onClick, domain: 'example.com' });
+      controller.appendTo(document.body);
+      
+      const dismissBtn = controller.element.querySelector('.extractmd-dismiss-btn');
+      dismissBtn.style.display = 'block';
+      
+      // Click dismiss button
+      dismissBtn.click();
+      
+      // Wait for async operations
+      await new Promise(resolve => setTimeout(resolve, 10));
+      
+      // Main onClick should not be called
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('does not show dismiss button when no domain provided', async () => {
+      vi.useFakeTimers();
+      
+      const onClick = vi.fn();
+      const controller = await createFloatingButton({ onClick }); // No domain
+      controller.appendTo(document.body);
+      
+      // Simulate mouseenter
+      const mouseenterEvent = new MouseEvent('mouseenter', { bubbles: true });
+      controller.element.dispatchEvent(mouseenterEvent);
+      
+      // Advance timer past HOVER_DELAY_MS
+      vi.advanceTimersByTime(600);
+      
+      // Dismiss button should still be hidden (no domain = no dismiss functionality)
+      const dismissBtn = controller.element.querySelector('.extractmd-dismiss-btn');
+      // Check that display is still none (not changed to block)
+      expect(dismissBtn.style.display).not.toBe('block');
+      
+      vi.useRealTimers();
+    });
+  });
+
+  describe('position offset storage', () => {
+    it('uses default position when no saved offset exists', async () => {
+      const onClick = vi.fn();
+      const controller = await createFloatingButton({ onClick, domain: 'example.com' });
+      controller.appendTo(document.body);
+      
+      // The button element should exist and be properly structured
+      expect(controller.element).toBeDefined();
+      expect(controller.element.id).toBe('extractmd-floating-button');
+      // Verify storage.local.get was called to load positions
+      expect(chrome.storage.local.get).toHaveBeenCalled();
+    });
+
+    it('applies saved offset to position', async () => {
+      // Setup mock to return a saved position
+      chrome.storage.local.get = vi.fn((keys, callback) => {
+        callback({
+          floatingButtonPositions: {
+            'test-domain.com': { left: 30, up: 50 }
+          }
+        });
+      });
+      
+      const onClick = vi.fn();
+      const controller = await createFloatingButton({ onClick, domain: 'test-domain.com' });
+      controller.appendTo(document.body);
+      
+      // Verify storage was called to load the position
+      expect(chrome.storage.local.get).toHaveBeenCalled();
+      // The button should be created (position is applied via cssText which jsdom may not parse fully)
+      expect(controller.element).toBeDefined();
+      expect(controller.element.id).toBe('extractmd-floating-button');
+    });
+  });
+});


### PR DESCRIPTION
Adds drag-to-reposition, hover-to-dismiss, and real-time button visibility updates for ignored domains.

## Changes
- **Drag-to-reposition**: Users can hold and drag the floating button to reposition it. Position is saved per-domain as an offset from the default bottom-right corner using `chrome.storage.local`
- **Dismiss button**: After hovering for 500ms, an X button appears in the top-right corner of the floating button. Clicking it adds the current domain to the ignore list and removes the button
- **Live ignore toggle**: Button now appears/disappears immediately when toggling ignore status from popup or dismiss button, without requiring page refresh
- **Settings**: Added two new settings (`floatingButtonEnableDrag` and `floatingButtonEnableDismiss`, both default to `true`) to control these features
- **Click prevention**: Fixed issue where clicking to place button after dragging would trigger extraction

## Benefits
- Better UX: Users can position the button where it doesn't interfere with page content
- Quick domain ignore: One-click dismiss without opening popup
- Immediate feedback: No page refresh needed when toggling ignore status
- Flexible: Users can disable drag or dismiss features if not needed
- Per-domain customization: Each domain remembers its button position independently