### PR TITLE
chore: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,132 @@
+name: Bug Report
+description: Report a bug or unexpected behavior in ExtractMD
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the sections below so we can reproduce and fix the issue quickly.
+
+  - type: input
+    id: version
+    attributes:
+      label: ExtractMD Version
+      description: "Find this in the extension popup or `chrome://extensions`."
+      placeholder: "e.g. 1.1.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: browser
+    attributes:
+      label: Browser
+      options:
+        - Chrome
+        - Chromium
+        - Brave
+        - Edge
+        - Arc
+        - Vivaldi
+        - Other (specify in description)
+    validations:
+      required: true
+
+  - type: input
+    id: browser-version
+    attributes:
+      label: Browser Version
+      description: "Find this in your browser's About page."
+      placeholder: "e.g. 134.0.6998.89"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - ChromeOS
+    validations:
+      required: true
+
+  - type: dropdown
+    id: integration
+    attributes:
+      label: Which integration is affected?
+      options:
+        - YouTube
+        - Hacker News
+        - X / Twitter
+        - Article Extraction
+        - Universal Extractor
+        - Popup / Settings
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of the bug.
+      placeholder: "When I try to extract a YouTube transcript, the button stays in the loading state and nothing is copied."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Exact steps to reproduce the behavior.
+      value: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Observe '...'
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened instead.
+    validations:
+      required: true
+
+  - type: input
+    id: url
+    attributes:
+      label: Page URL
+      description: "The URL where the issue occurs (if applicable)."
+      placeholder: "https://www.youtube.com/watch?v=..."
+
+  - type: textarea
+    id: console-errors
+    attributes:
+      label: Console Errors
+      description: "Open DevTools (F12) → Console tab and paste any relevant errors."
+      render: text
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: "Drag and drop screenshots here if they help illustrate the problem."
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other information that might help (custom settings, other extensions, etc.).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ExtractMD Website
+    url: https://extractmd.miguelcorderocollar.com/
+    about: Visit the official ExtractMD website for general information.
+  - name: Privacy Policy
+    url: https://extractmd.miguelcorderocollar.com/privacy.html
+    about: Read our privacy policy to understand how ExtractMD handles your data.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,66 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for ExtractMD
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe your idea so we can evaluate and prioritize it.
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Feature Category
+      options:
+        - New Integration (website/platform support)
+        - Extraction Quality (better output formatting)
+        - User Interface (popup, options page, button)
+        - Settings / Configuration
+        - Keyboard Shortcuts
+        - Performance
+        - Developer Experience (testing, build, docs)
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or Use Case
+      description: "What problem does this feature solve? What's the use case?"
+      placeholder: "I often need to extract content from Reddit threads, but there's no dedicated integration..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or workarounds you've considered.
+
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Impact
+      description: How many users would benefit from this feature?
+      options:
+        - Low (nice to have, niche use case)
+        - Medium (useful for many users)
+        - High (significant improvement for most users)
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: "Screenshots, mockups, links to similar tools, or anything else that helps explain the request."

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,41 @@
+name: Question / Support
+description: Ask a question or get help using ExtractMD
+title: "[Question]: "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question about using ExtractMD? We're happy to help!
+
+        Before opening an issue, please check:
+        - [README](https://github.com/miguelcorderocollar/ExtractMD#readme)
+        - [Existing issues](https://github.com/miguelcorderocollar/ExtractMD/issues?q=is%3Aissue)
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your Question
+      description: What would you like to know?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: topic
+    attributes:
+      label: Topic
+      options:
+        - Installation / Setup
+        - Usage / How-to
+        - Configuration / Settings
+        - Integration-specific (YouTube, HN, X, etc.)
+        - Contributing / Development
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: "Any screenshots, URLs, or details that help clarify your question."

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,52 @@
+## Summary
+
+<!-- One-sentence description of what this PR does and why. -->
+
+## Changes
+
+<!-- List the key changes made in this PR. -->
+
+-
+
+## Type of Change
+
+<!-- Check the relevant option(s). -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Refactoring (no functional changes)
+- [ ] Documentation update
+- [ ] Build / CI / tooling change
+
+## Testing
+
+<!-- Describe how you tested your changes. -->
+
+- [ ] Existing tests pass (`pnpm test`)
+- [ ] New tests added for changed functionality
+- [ ] Manually tested in Chrome (specify version: )
+- [ ] Tested on relevant pages (list URLs if applicable)
+
+## Integration Coverage
+
+<!-- If your change affects a specific integration, check it below. -->
+
+- [ ] YouTube
+- [ ] Hacker News
+- [ ] X / Twitter
+- [ ] Article Extraction
+- [ ] Universal Extractor
+- [ ] Popup / Options UI
+- [ ] N/A
+
+## Screenshots
+
+<!-- If applicable, add before/after screenshots. -->
+
+## Checklist
+
+- [ ] My code follows the project's style guidelines (`pnpm run lint`)
+- [ ] I have performed a self-review of my code
+- [ ] I have updated `CHANGELOG.md` (under `## [Unreleased]`)
+- [ ] My changes do not introduce new warnings or errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **X Integration (Posts + Articles)**: Added dedicated extraction for X/Twitter status pages and long-form X articles with metadata (`title`, author handle, date, link), rich media handling (images, video/card placeholders), quoted-post markdown blocks, metrics-context extraction toggle (comments/reposts/likes/bookmarks/views + extraction timestamp), and new X settings/KPI tracking.
+- **Contribution Templates**: Added GitHub issue forms (bug report, feature request, question/support), issue template configuration, pull request template, and a new `CONTRIBUTING.md` guide to standardize community contributions.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,132 @@
+# Contributing to ExtractMD
+
+Thanks for your interest in contributing to ExtractMD! This guide will help you get started.
+
+## Getting Started
+
+### Prerequisites
+
+- **Node.js** (LTS version recommended)
+- **pnpm** (package manager)
+- **Chrome** or a Chromium-based browser
+
+### Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/miguelcorderocollar/ExtractMD.git
+cd ExtractMD
+
+# Install dependencies
+pnpm install
+
+# Run the development build
+pnpm run build
+
+# Run tests
+pnpm test
+```
+
+### Loading the Extension Locally
+
+1. Open `chrome://extensions` in Chrome
+2. Enable **Developer mode** (top-right toggle)
+3. Click **Load unpacked**
+4. Select the `extension/` folder from the project root
+
+## Development Workflow
+
+### Branch Naming
+
+Create a branch from `main` using one of these prefixes:
+
+- `feat/<description>` — new feature
+- `fix/<description>` — bug fix
+- `refactor/<description>` — code refactoring
+- `chore/<description>` — tooling, CI, docs, etc.
+
+### Code Quality
+
+Before submitting your changes, make sure everything passes:
+
+```bash
+# Format code
+pnpm run format
+
+# Lint
+pnpm run lint
+
+# Run tests
+pnpm test
+```
+
+Pre-commit hooks will automatically format staged files, but running the full suite ensures consistency.
+
+### Testing
+
+ExtractMD uses **Vitest** for unit tests and **Playwright** for end-to-end tests.
+
+- Unit tests live in `tests/unit/`
+- E2E tests live in `tests/e2e/`
+
+When adding a new feature or fixing a bug, include tests that verify the behavior.
+
+### Changelog
+
+Update `CHANGELOG.md` under `## [Unreleased]` with a brief description of your change. Follow the [Keep a Changelog](https://keepachangelog.com/) format.
+
+## Submitting a Pull Request
+
+1. Push your branch to your fork (or the repository if you have access)
+2. Open a pull request against `main`
+3. Fill out the PR template — it will appear automatically
+4. Make sure CI checks pass
+5. A maintainer will review your PR
+
+### PR Guidelines
+
+- Keep PRs focused — one feature or fix per PR
+- Write a clear title using conventional commit style (e.g., `feat: add Reddit integration`)
+- Include before/after screenshots for UI changes
+- Reference related issues (e.g., `Closes #42`)
+
+## Reporting Issues
+
+Use our [issue templates](https://github.com/miguelcorderocollar/ExtractMD/issues/new/choose) to:
+
+- **Report a bug** — include reproduction steps, expected vs. actual behavior, and browser/version info
+- **Request a feature** — describe the use case and proposed solution
+- **Ask a question** — if you need help using or configuring ExtractMD
+
+## Architecture Overview
+
+ExtractMD is a Chrome Extension (Manifest V3) with this structure:
+
+```
+extension/
+├── content/           # Content scripts (per-site extractors)
+│   ├── components/    # Shared UI components (FloatingButton, etc.)
+│   ├── youtube/       # YouTube integration
+│   ├── hackernews/    # Hacker News integration
+│   ├── x/             # X/Twitter integration
+│   └── ...
+├── shared/            # Shared utilities and modules
+├── popup.html/js      # Extension popup
+├── options.html/js    # Settings page
+├── background.js      # Service worker
+└── manifest.json
+```
+
+Key principles:
+
+- **Modular extractors** — each site integration lives in its own directory
+- **Shared components** — reusable UI elements in `content/components/`
+- **Local processing** — all data processing happens in the browser, no external servers
+
+## Code of Conduct
+
+Be respectful and constructive. We're building something useful together.
+
+## Questions?
+
+Open a [question issue](https://github.com/miguelcorderocollar/ExtractMD/issues/new?template=question.yml) or reach out through the project's GitHub page.


### PR DESCRIPTION
## Summary
Standardize contribution workflows by adding GitHub issue forms, a PR template, and a contributor guide so reports and pull requests arrive with complete, actionable context.

## Changes
- Add `.github/ISSUE_TEMPLATE/` forms for bug reports, feature requests, and question/support issues
- Add `.github/ISSUE_TEMPLATE/config.yml` to disable blank issues and provide contact links
- Add `.github/pull_request_template.md` with testing and quality checklists
- Add `CONTRIBUTING.md` with setup, testing, branching, and PR guidelines
- Update `CHANGELOG.md` under `## [Unreleased]`

## Test plan
- [x] Verify template files are present in `.github/ISSUE_TEMPLATE/`
- [x] Validate YAML structure for GitHub issue forms
- [x] Confirm PR template includes summary, change type, testing, and checklist sections
- [x] Confirm changelog entry added in `CHANGELOG.md`

Made with [Cursor](https://cursor.com)