### PR TITLE
feat: add frosted glass floating button style

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Report a bug or unexpected behavior in ExtractMD
-title: "[Bug]: "
-labels: ["bug"]
+title: '[Bug]: '
+labels: ['bug']
 body:
   - type: markdown
     attributes:
@@ -12,8 +12,8 @@ body:
     id: version
     attributes:
       label: ExtractMD Version
-      description: "Find this in the extension popup or `chrome://extensions`."
-      placeholder: "e.g. 1.1.0"
+      description: 'Find this in the extension popup or `chrome://extensions`.'
+      placeholder: 'e.g. 1.1.0'
     validations:
       required: true
 
@@ -37,7 +37,7 @@ body:
     attributes:
       label: Browser Version
       description: "Find this in your browser's About page."
-      placeholder: "e.g. 134.0.6998.89"
+      placeholder: 'e.g. 134.0.6998.89'
     validations:
       required: true
 
@@ -73,7 +73,7 @@ body:
     attributes:
       label: Bug Description
       description: A clear and concise description of the bug.
-      placeholder: "When I try to extract a YouTube transcript, the button stays in the loading state and nothing is copied."
+      placeholder: 'When I try to extract a YouTube transcript, the button stays in the loading state and nothing is copied.'
     validations:
       required: true
 
@@ -109,21 +109,21 @@ body:
     id: url
     attributes:
       label: Page URL
-      description: "The URL where the issue occurs (if applicable)."
-      placeholder: "https://www.youtube.com/watch?v=..."
+      description: 'The URL where the issue occurs (if applicable).'
+      placeholder: 'https://www.youtube.com/watch?v=...'
 
   - type: textarea
     id: console-errors
     attributes:
       label: Console Errors
-      description: "Open DevTools (F12) → Console tab and paste any relevant errors."
+      description: 'Open DevTools (F12) → Console tab and paste any relevant errors.'
       render: text
 
   - type: textarea
     id: screenshots
     attributes:
       label: Screenshots
-      description: "Drag and drop screenshots here if they help illustrate the problem."
+      description: 'Drag and drop screenshots here if they help illustrate the problem.'
 
   - type: textarea
     id: additional

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest a new feature or enhancement for ExtractMD
-title: "[Feature]: "
-labels: ["enhancement"]
+title: '[Feature]: '
+labels: ['enhancement']
 body:
   - type: markdown
     attributes:
@@ -63,4 +63,4 @@ body:
     id: additional
     attributes:
       label: Additional Context
-      description: "Screenshots, mockups, links to similar tools, or anything else that helps explain the request."
+      description: 'Screenshots, mockups, links to similar tools, or anything else that helps explain the request.'

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,7 +1,7 @@
 name: Question / Support
 description: Ask a question or get help using ExtractMD
-title: "[Question]: "
-labels: ["question"]
+title: '[Question]: '
+labels: ['question']
 body:
   - type: markdown
     attributes:
@@ -38,4 +38,4 @@ body:
     id: context
     attributes:
       label: Additional Context
-      description: "Any screenshots, URLs, or details that help clarify your question."
+      description: 'Any screenshots, URLs, or details that help clarify your question.'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **X Integration (Posts + Articles)**: Added dedicated extraction for X/Twitter status pages and long-form X articles with metadata (`title`, author handle, date, link), rich media handling (images, video/card placeholders), quoted-post markdown blocks, metrics-context extraction toggle (comments/reposts/likes/bookmarks/views + extraction timestamp), and new X settings/KPI tracking.
 - **Contribution Templates**: Added GitHub issue forms (bug report, feature request, question/support), issue template configuration, pull request template, and a new `CONTRIBUTING.md` guide to standardize community contributions.
+- **Frosted Glass Floating Button**: New "Glass" button style option that renders the floating button as a colorless frosted glass element using `backdrop-filter` blur and saturation, with subtle white borders and inset highlights. Glass is now the default style; users can switch back to solid (accent-colored) in settings.
 
 ### Fixed
 

--- a/extension/content/components/FloatingButton.js
+++ b/extension/content/components/FloatingButton.js
@@ -108,7 +108,7 @@ async function loadPositionOffset(domain) {
 
 /**
  * Load all button settings from storage in a single call
- * @returns {Promise<{size: string, transparency: string, accentColor: string}>}
+ * @returns {Promise<{size: string, transparency: string, style: string, accentColor: string}>}
  */
 async function loadButtonSettings() {
   return new Promise((resolve) => {
@@ -116,12 +116,14 @@ async function loadButtonSettings() {
       {
         floatingButtonSize: 'medium',
         floatingButtonTransparency: 'medium',
+        floatingButtonStyle: 'glass',
         accentColor: DEFAULTS.accentColor,
       },
       (items) => {
         resolve({
           size: items.floatingButtonSize || 'medium',
           transparency: items.floatingButtonTransparency || 'medium',
+          style: items.floatingButtonStyle || 'glass',
           accentColor: items.accentColor || DEFAULTS.accentColor,
         });
       }
@@ -216,9 +218,35 @@ export async function createFloatingButton({
   let currentOffset = { ...positionOffset };
   const sizeConfig = SIZE_CONFIG[settings.size] || SIZE_CONFIG.medium;
   const idleOpacity = TRANSPARENCY_CONFIG[settings.transparency] || TRANSPARENCY_CONFIG.medium;
+  const isGlass = settings.style === 'glass';
 
   // Get theme colors using loaded accent color
   const colors = getThemeColors(settings.accentColor);
+
+  // Pre-compute glass-specific values (colorless frosted glass, no accent tint)
+  const dark = isDarkMode();
+  const glassBg = isGlass
+    ? dark
+      ? 'rgba(255, 255, 255, 0.12)'
+      : 'rgba(255, 255, 255, 0.15)'
+    : null;
+  const glassHoverBg = isGlass
+    ? dark
+      ? 'rgba(255, 255, 255, 0.22)'
+      : 'rgba(255, 255, 255, 0.3)'
+    : null;
+  const glassBorder = isGlass
+    ? dark
+      ? '1px solid rgba(255, 255, 255, 0.18)'
+      : '1px solid rgba(255, 255, 255, 0.5)'
+    : null;
+  const glassBoxShadow = isGlass
+    ? '0 4px 24px -1px rgba(0, 0, 0, 0.2), inset 0 1px 0 0 rgba(255, 255, 255, 0.25)'
+    : null;
+  const glassHoverBoxShadow = isGlass
+    ? '0 6px 28px -1px rgba(0, 0, 0, 0.3), inset 0 1px 0 0 rgba(255, 255, 255, 0.35)'
+    : null;
+  const glassIconColor = isGlass ? '#ffffff' : null;
 
   const button = document.createElement('div');
   button.id = id;
@@ -235,7 +263,7 @@ export async function createFloatingButton({
   cs.display = 'flex';
   cs.alignItems = 'center';
   cs.justifyContent = 'center';
-  cs.color = colors.iconColor;
+  cs.color = isGlass ? glassIconColor : colors.iconColor;
 
   const svg = contentContainer.querySelector('svg');
   if (svg) {
@@ -282,9 +310,6 @@ export async function createFloatingButton({
   bs.width = `${sizeConfig.size}px`;
   bs.height = `${sizeConfig.size}px`;
   bs.cursor = 'pointer';
-  bs.background = colors.accent;
-  bs.border = 'none';
-  bs.boxShadow = '0 4px 12px rgba(0,0,0,0.15)';
   bs.zIndex = '10000';
   bs.display = 'flex';
   bs.alignItems = 'center';
@@ -293,6 +318,18 @@ export async function createFloatingButton({
     'box-shadow 0.2s ease, opacity 0.2s ease, background 0.2s ease, transform 0.2s ease';
   bs.userSelect = 'none';
   bs.opacity = idleOpacity.toString();
+
+  if (isGlass) {
+    bs.background = glassBg;
+    bs.border = glassBorder;
+    bs.boxShadow = glassBoxShadow;
+    bs.backdropFilter = 'blur(12px) saturate(180%)';
+    bs.webkitBackdropFilter = 'blur(12px) saturate(180%)';
+  } else {
+    bs.background = colors.accent;
+    bs.border = 'none';
+    bs.boxShadow = '0 4px 12px rgba(0,0,0,0.15)';
+  }
 
   // Drag state
   let isDragging = false;
@@ -410,10 +447,16 @@ export async function createFloatingButton({
   button.addEventListener('mouseenter', () => {
     if (!button.dataset.processing) {
       isHovering = true;
-      button.style.boxShadow = '0 6px 16px rgba(0,0,0,0.25)';
       button.style.opacity = '1';
-      button.style.background = colors.accentHover;
       button.style.transform = 'scale(1.05)';
+
+      if (isGlass) {
+        button.style.background = glassHoverBg;
+        button.style.boxShadow = glassHoverBoxShadow;
+      } else {
+        button.style.background = colors.accentHover;
+        button.style.boxShadow = '0 6px 16px rgba(0,0,0,0.25)';
+      }
 
       // Start timer to show dismiss button (only if dismiss is enabled)
       if (domain && enableDismiss) {
@@ -439,10 +482,16 @@ export async function createFloatingButton({
     dismissBtn.style.display = 'none';
 
     if (!button.dataset.processing) {
-      button.style.boxShadow = '0 4px 12px rgba(0,0,0,0.15)';
       button.style.opacity = idleOpacity.toString();
-      button.style.background = colors.accent;
       button.style.transform = 'scale(1)';
+
+      if (isGlass) {
+        button.style.background = glassBg;
+        button.style.boxShadow = glassBoxShadow;
+      } else {
+        button.style.background = colors.accent;
+        button.style.boxShadow = '0 4px 12px rgba(0,0,0,0.15)';
+      }
     }
   });
 
@@ -530,7 +579,8 @@ export async function createFloatingButton({
      */
     setLoading() {
       button.dataset.processing = 'true';
-      updateIcon(ICONS.loading, colors.iconColor);
+      const iconClr = isGlass ? glassIconColor : colors.iconColor;
+      updateIcon(ICONS.loading, iconClr);
       button.style.background = colors.loading;
       button.style.cursor = 'not-allowed';
       button.style.opacity = '1';
@@ -542,7 +592,8 @@ export async function createFloatingButton({
      * Set button to success state
      */
     setSuccess() {
-      updateIcon(ICONS.success, colors.iconColor);
+      const iconClr = isGlass ? glassIconColor : colors.iconColor;
+      updateIcon(ICONS.success, iconClr);
       button.style.background = colors.success;
       button.style.opacity = '1';
       button.style.transform = 'scale(1)';
@@ -552,7 +603,8 @@ export async function createFloatingButton({
      * Set button to error state
      */
     setError() {
-      updateIcon(ICONS.error, colors.iconColor);
+      const iconClr = isGlass ? glassIconColor : colors.iconColor;
+      updateIcon(ICONS.error, iconClr);
       button.style.background = colors.error;
       button.style.opacity = '1';
       button.style.transform = 'scale(1)';
@@ -563,8 +615,9 @@ export async function createFloatingButton({
      */
     setNormal() {
       delete button.dataset.processing;
-      updateIcon(ICONS.clipboard, colors.iconColor);
-      button.style.background = colors.accent;
+      const iconClr = isGlass ? glassIconColor : colors.iconColor;
+      updateIcon(ICONS.clipboard, iconClr);
+      button.style.background = isGlass ? glassBg : colors.accent;
       button.style.cursor = 'pointer';
       button.style.opacity = idleOpacity.toString();
       button.style.transform = 'scale(1)';

--- a/extension/options.html
+++ b/extension/options.html
@@ -249,6 +249,15 @@
               <option value="high">High (70%)</option>
               <option value="full">Full (100%)</option>
             </setting-select>
+            <setting-select
+              setting-id="floatingButtonStyle"
+              label="Button Style"
+              description="Solid uses your accent color. Glass is a transparent frosted effect."
+              value="glass"
+            >
+              <option value="solid">Solid</option>
+              <option value="glass">Glass (Frosted)</option>
+            </setting-select>
           </setting-group>
 
           <div class="settings-group">

--- a/extension/options/settings.js
+++ b/extension/options/settings.js
@@ -104,6 +104,7 @@ const SETTING_ELEMENTS = {
   floatingButtonEnableDismiss: { id: 'floatingButtonEnableDismiss', type: 'checkbox' },
   floatingButtonSize: { id: 'floatingButtonSize', type: 'select' },
   floatingButtonTransparency: { id: 'floatingButtonTransparency', type: 'select' },
+  floatingButtonStyle: { id: 'floatingButtonStyle', type: 'select' },
 };
 
 /**

--- a/extension/shared/defaults.js
+++ b/extension/shared/defaults.js
@@ -71,6 +71,7 @@ export const DEFAULTS = {
   floatingButtonEnableDismiss: true,
   floatingButtonSize: 'medium', // 'small' | 'medium' | 'large'
   floatingButtonTransparency: 'medium', // 'low' | 'medium' | 'high' | 'full'
+  floatingButtonStyle: 'glass', // 'solid' | 'glass'
 
   // Theme
   accentColor: '#14b8a6', // Default teal
@@ -133,6 +134,7 @@ export const SETTING_SCHEMA = {
   floatingButtonEnableDismiss: 'boolean',
   floatingButtonSize: 'string',
   floatingButtonTransparency: 'string',
+  floatingButtonStyle: 'string',
   accentColor: 'string',
   welcomeCompleted: 'boolean',
 };

--- a/tests/unit/content/components/FloatingButton.test.js
+++ b/tests/unit/content/components/FloatingButton.test.js
@@ -23,6 +23,7 @@ describe('FloatingButton component', () => {
               ignoredDomains: '',
               floatingButtonSize: 'medium',
               floatingButtonTransparency: 'medium',
+              floatingButtonStyle: 'glass',
               accentColor: '#14b8a6',
             });
           }),
@@ -121,13 +122,13 @@ describe('FloatingButton component', () => {
   });
 
   describe('button appearance', () => {
-    it('creates button with default teal accent background color', async () => {
+    it('creates button with default frosted glass background', async () => {
       const onClick = vi.fn();
       const controller = await createFloatingButton({ onClick });
 
       expect(controller).not.toBeNull();
-      // Light mode uses #14b8a6 - jsdom converts to rgb
-      expect(controller.element.style.background).toBe('rgb(20, 184, 166)');
+      // Default is glass style: neutral white rgba background
+      expect(controller.element.style.background).toContain('rgba(255, 255, 255');
     });
 
     it('creates button with rounded square shape (not circular)', async () => {
@@ -281,6 +282,15 @@ describe('FloatingButton component', () => {
         removeEventListener: vi.fn(),
       }));
 
+      chrome.storage.sync.get = vi.fn((keys, callback) => {
+        callback({
+          floatingButtonSize: 'medium',
+          floatingButtonTransparency: 'medium',
+          floatingButtonStyle: 'solid',
+          accentColor: '#14b8a6',
+        });
+      });
+
       const onClick = vi.fn();
       const controller = await createFloatingButton({ onClick });
 
@@ -296,20 +306,30 @@ describe('FloatingButton component', () => {
         removeEventListener: vi.fn(),
       }));
 
+      chrome.storage.sync.get = vi.fn((keys, callback) => {
+        callback({
+          floatingButtonSize: 'medium',
+          floatingButtonTransparency: 'medium',
+          floatingButtonStyle: 'solid',
+          accentColor: '#14b8a6',
+        });
+      });
+
       const onClick = vi.fn();
       const controller = await createFloatingButton({ onClick });
 
       // Dark mode uses a lightened accent color for better visibility
-      // The exact color depends on ColorUtils.lighten(#14b8a6, 10)
       expect(controller.element.style.background).not.toBe('');
       // Just verify it's different from light mode (rgb(20, 184, 166))
       expect(controller.element.style.background).not.toBe('rgb(20, 184, 166)');
     });
 
     it('uses custom accent color from storage', async () => {
-      // Mock storage to return custom color
       chrome.storage.sync.get = vi.fn((keys, callback) => {
-        callback({ accentColor: '#ff0000' }); // Red
+        callback({
+          floatingButtonStyle: 'solid',
+          accentColor: '#ff0000',
+        });
       });
 
       const onClick = vi.fn();
@@ -319,9 +339,11 @@ describe('FloatingButton component', () => {
     });
 
     it('computes hover variant correctly', async () => {
-      // Mock storage to return blue color
       chrome.storage.sync.get = vi.fn((keys, callback) => {
-        callback({ accentColor: '#0066cc' }); // Blue
+        callback({
+          floatingButtonStyle: 'solid',
+          accentColor: '#0066cc',
+        });
       });
 
       const onClick = vi.fn();
@@ -762,6 +784,109 @@ describe('FloatingButton component', () => {
       // Hover uses a darkened version of the accent color
       expect(controller.element.style.background).not.toBe('');
       expect(controller.element.style.background).not.toBe(initialBg);
+    });
+  });
+
+  describe('glass style', () => {
+    it('uses solid style when configured (no backdrop-filter)', async () => {
+      chrome.storage.sync.get = vi.fn((keys, callback) => {
+        callback({
+          floatingButtonSize: 'medium',
+          floatingButtonTransparency: 'medium',
+          floatingButtonStyle: 'solid',
+          accentColor: '#14b8a6',
+        });
+      });
+
+      const onClick = vi.fn();
+      const controller = await createFloatingButton({ onClick });
+
+      // Solid style should not set backdrop-filter
+      expect(controller.element.style.backdropFilter || '').toBe('');
+      // Solid style sets border to 'none' (jsdom serializes as 'medium')
+      expect(controller.element.style.borderStyle).toBe('none');
+    });
+
+    it('uses glass style by default (colorless frosted glass)', async () => {
+      const onClick = vi.fn();
+      const controller = await createFloatingButton({ onClick });
+
+      // Glass background should be neutral white rgba (no accent color)
+      const bg = controller.element.style.background;
+      expect(bg).toContain('rgba');
+      expect(bg).toContain('255');
+      expect(bg).not.toContain('184'); // No accent tint (teal green component)
+
+      // Glass style should set a visible border
+      expect(controller.element.style.border).not.toBe('none');
+      expect(controller.element.style.border).toContain('rgba');
+    });
+
+    it('glass style hover updates background while keeping glass effect', async () => {
+      chrome.storage.sync.get = vi.fn((keys, callback) => {
+        callback({
+          floatingButtonSize: 'medium',
+          floatingButtonTransparency: 'medium',
+          floatingButtonStyle: 'glass',
+          accentColor: '#14b8a6',
+        });
+      });
+
+      const onClick = vi.fn();
+      const controller = await createFloatingButton({ onClick });
+      controller.appendTo(document.body);
+
+      const initialBg = controller.element.style.background;
+
+      const mouseenterEvent = new MouseEvent('mouseenter', { bubbles: true });
+      controller.element.dispatchEvent(mouseenterEvent);
+
+      // Hover should change background
+      expect(controller.element.style.background).not.toBe(initialBg);
+    });
+
+    it('glass style setNormal restores glass background', async () => {
+      chrome.storage.sync.get = vi.fn((keys, callback) => {
+        callback({
+          floatingButtonSize: 'medium',
+          floatingButtonTransparency: 'medium',
+          floatingButtonStyle: 'glass',
+          accentColor: '#14b8a6',
+        });
+      });
+
+      const onClick = vi.fn();
+      const controller = await createFloatingButton({ onClick });
+
+      const initialBg = controller.element.style.background;
+
+      controller.setLoading();
+      controller.setNormal();
+
+      expect(controller.element.style.background).toBe(initialBg);
+    });
+
+    it('glass style loading/success/error states use opaque colors', async () => {
+      chrome.storage.sync.get = vi.fn((keys, callback) => {
+        callback({
+          floatingButtonSize: 'medium',
+          floatingButtonTransparency: 'medium',
+          floatingButtonStyle: 'glass',
+          accentColor: '#14b8a6',
+        });
+      });
+
+      const onClick = vi.fn();
+      const controller = await createFloatingButton({ onClick });
+
+      controller.setLoading();
+      expect(controller.element.style.background).toBe('rgb(245, 158, 11)');
+
+      controller.setSuccess();
+      expect(controller.element.style.background).toBe('rgb(34, 197, 94)');
+
+      controller.setError();
+      expect(controller.element.style.background).toBe('rgb(239, 68, 68)');
     });
   });
 

--- a/tests/unit/options/floatingButton.test.js
+++ b/tests/unit/options/floatingButton.test.js
@@ -14,11 +14,13 @@ describe('Floating Button Settings', () => {
     expect(DEFAULTS).toHaveProperty('floatingButtonEnableDismiss');
     expect(DEFAULTS).toHaveProperty('floatingButtonSize');
     expect(DEFAULTS).toHaveProperty('floatingButtonTransparency');
+    expect(DEFAULTS).toHaveProperty('floatingButtonStyle');
 
     expect(DEFAULTS.floatingButtonEnableDrag).toBe(true);
     expect(DEFAULTS.floatingButtonEnableDismiss).toBe(true);
     expect(DEFAULTS.floatingButtonSize).toBe('medium');
     expect(DEFAULTS.floatingButtonTransparency).toBe('medium');
+    expect(DEFAULTS.floatingButtonStyle).toBe('glass');
   });
 
   it('should save floating button settings correctly', async () => {
@@ -64,6 +66,14 @@ describe('Floating Button Settings', () => {
     // Save default transparency (should call remove)
     saveSetting('floatingButtonTransparency', 'medium');
     expect(removeSpy).toHaveBeenCalledWith('floatingButtonTransparency', expect.any(Function));
+
+    // Save non-default style (should call set)
+    saveSetting('floatingButtonStyle', 'solid');
+    expect(setSpy).toHaveBeenCalledWith({ floatingButtonStyle: 'solid' }, expect.any(Function));
+
+    // Save default style (should call remove)
+    saveSetting('floatingButtonStyle', 'glass');
+    expect(removeSpy).toHaveBeenCalledWith('floatingButtonStyle', expect.any(Function));
   });
 
   it('should load floating button settings with defaults', async () => {
@@ -79,6 +89,7 @@ describe('Floating Button Settings', () => {
               floatingButtonEnableDismiss: true,
               floatingButtonSize: 'medium',
               floatingButtonTransparency: 'medium',
+              floatingButtonStyle: 'glass',
             });
           }),
         },
@@ -90,12 +101,14 @@ describe('Floating Button Settings', () => {
       'floatingButtonEnableDismiss',
       'floatingButtonSize',
       'floatingButtonTransparency',
+      'floatingButtonStyle',
     ]);
 
     expect(settings.floatingButtonEnableDrag).toBe(true);
     expect(settings.floatingButtonEnableDismiss).toBe(true);
     expect(settings.floatingButtonSize).toBe('medium');
     expect(settings.floatingButtonTransparency).toBe('medium');
+    expect(settings.floatingButtonStyle).toBe('glass');
   });
 
   it('should have floating button settings in SETTING_SCHEMA', async () => {
@@ -105,6 +118,7 @@ describe('Floating Button Settings', () => {
     expect(SETTING_SCHEMA).toHaveProperty('floatingButtonEnableDismiss', 'boolean');
     expect(SETTING_SCHEMA).toHaveProperty('floatingButtonSize', 'string');
     expect(SETTING_SCHEMA).toHaveProperty('floatingButtonTransparency', 'string');
+    expect(SETTING_SCHEMA).toHaveProperty('floatingButtonStyle', 'string');
   });
 
   it('should reset all floating button positions', async () => {

--- a/tests/unit/shared/defaults.test.js
+++ b/tests/unit/shared/defaults.test.js
@@ -75,6 +75,7 @@ describe('shared/defaults', () => {
     expect(DEFAULTS.floatingButtonEnableDismiss).toBe(true);
     expect(DEFAULTS.floatingButtonSize).toBe('medium');
     expect(DEFAULTS.floatingButtonTransparency).toBe('medium');
+    expect(DEFAULTS.floatingButtonStyle).toBe('glass');
 
     // Theme
     expect(DEFAULTS.accentColor).toBe('#14b8a6');


### PR DESCRIPTION
## Summary

- Add colorless frosted glass style option for the floating button using `backdrop-filter: blur(12px) saturate(180%)` with neutral white backgrounds, subtle borders, and inset highlights
- Glass is now the default button style; solid (accent-colored) remains available in settings
- Closes #34

## Changes

- **`FloatingButton.js`**: Replaced accent-tinted glass with true colorless frosted glass (neutral `rgba(255,255,255,...)` backgrounds, white icon, Apple-inspired inset shadows and border highlights)
- **`defaults.js`**: Changed `floatingButtonStyle` default from `'solid'` to `'glass'`
- **`options.html`**: Updated setting description and default value
- **`CHANGELOG.md`**: Added frosted glass feature entry
- **Tests**: Updated all glass/solid style tests to reflect new default; all 301 tests pass

## Benefits

- Clean, modern look that works on any page background without clashing
- Clear separation: solid = your accent color, glass = transparent frosted effect
- No accent color bleeding into the glass — pure Apple-style frosted glass


Made with [Cursor](https://cursor.com)