### PR TITLE
fix: keep floating button status states subtly translucent in glass mode

### DIFF
--- a/extension/content/components/FloatingButton.js
+++ b/extension/content/components/FloatingButton.js
@@ -251,6 +251,21 @@ export async function createFloatingButton({
     ? '0 6px 28px -1px rgba(0, 0, 0, 0.3), inset 0 1px 0 0 rgba(255, 255, 255, 0.35)'
     : null;
   const glassIconColor = isGlass ? '#ffffff' : null;
+  const glassLoadingBg = isGlass
+    ? dark
+      ? 'rgba(251, 191, 36, 0.24)'
+      : 'rgba(245, 158, 11, 0.2)'
+    : null;
+  const glassSuccessBg = isGlass
+    ? dark
+      ? 'rgba(74, 222, 128, 0.24)'
+      : 'rgba(34, 197, 94, 0.2)'
+    : null;
+  const glassErrorBg = isGlass
+    ? dark
+      ? 'rgba(248, 113, 113, 0.24)'
+      : 'rgba(239, 68, 68, 0.2)'
+    : null;
 
   const button = document.createElement('div');
   button.id = id;
@@ -622,7 +637,7 @@ export async function createFloatingButton({
       button.dataset.processing = 'true';
       const iconClr = isGlass ? glassIconColor : colors.iconColor;
       updateIcon(ICONS.loading, iconClr);
-      button.style.background = colors.loading;
+      button.style.background = isGlass ? glassLoadingBg : colors.loading;
       button.style.cursor = 'not-allowed';
       button.style.opacity = '1';
       button.style.transform = 'scale(1)';
@@ -635,7 +650,7 @@ export async function createFloatingButton({
     setSuccess() {
       const iconClr = isGlass ? glassIconColor : colors.iconColor;
       updateIcon(ICONS.success, iconClr);
-      button.style.background = colors.success;
+      button.style.background = isGlass ? glassSuccessBg : colors.success;
       button.style.opacity = '1';
       button.style.transform = 'scale(1)';
     },
@@ -646,7 +661,7 @@ export async function createFloatingButton({
     setError() {
       const iconClr = isGlass ? glassIconColor : colors.iconColor;
       updateIcon(ICONS.error, iconClr);
-      button.style.background = colors.error;
+      button.style.background = isGlass ? glassErrorBg : colors.error;
       button.style.opacity = '1';
       button.style.transform = 'scale(1)';
     },

--- a/tests/unit/content/components/FloatingButton.test.js
+++ b/tests/unit/content/components/FloatingButton.test.js
@@ -413,14 +413,13 @@ describe('FloatingButton component', () => {
       expect(controller.element.style.cursor).toBe('not-allowed');
     });
 
-    it('setLoading uses warning color for background', async () => {
+    it('setLoading uses translucent warning glass background by default', async () => {
       const onClick = vi.fn();
       const controller = await createFloatingButton({ onClick });
 
       controller.setLoading();
 
-      // Light mode loading color is #f59e0b = rgb(245, 158, 11)
-      expect(controller.element.style.background).toBe('rgb(245, 158, 11)');
+      expect(controller.element.style.background).toBe('rgba(245, 158, 11, 0.2)');
     });
 
     it('setSuccess updates button to success state with checkmark', async () => {
@@ -438,14 +437,36 @@ describe('FloatingButton component', () => {
       expect(innerHTML).toMatch(/points=['"]20\s+6\s+9\s+17\s+4\s+12['"]/);
     });
 
-    it('setSuccess uses success color for background', async () => {
+    it('setSuccess uses translucent success glass background by default', async () => {
       const onClick = vi.fn();
       const controller = await createFloatingButton({ onClick });
 
       controller.setSuccess();
 
-      // Light mode success color is #22c55e = rgb(34, 197, 94)
+      expect(controller.element.style.background).toBe('rgba(34, 197, 94, 0.2)');
+    });
+
+    it('solid style loading/success/error states keep opaque colors', async () => {
+      chrome.storage.sync.get = vi.fn((keys, callback) => {
+        callback({
+          floatingButtonSize: 'medium',
+          floatingButtonTransparency: 'medium',
+          floatingButtonStyle: 'solid',
+          accentColor: '#14b8a6',
+        });
+      });
+
+      const onClick = vi.fn();
+      const controller = await createFloatingButton({ onClick });
+
+      controller.setLoading();
+      expect(controller.element.style.background).toBe('rgb(245, 158, 11)');
+
+      controller.setSuccess();
       expect(controller.element.style.background).toBe('rgb(34, 197, 94)');
+
+      controller.setError();
+      expect(controller.element.style.background).toBe('rgb(239, 68, 68)');
     });
 
     it('setError updates button to error state with X icon', async () => {
@@ -463,14 +484,13 @@ describe('FloatingButton component', () => {
       expect(innerHTML).toMatch(/x2[=:]['"]6['"]/i);
     });
 
-    it('setError uses error color for background', async () => {
+    it('setError uses translucent error glass background by default', async () => {
       const onClick = vi.fn();
       const controller = await createFloatingButton({ onClick });
 
       controller.setError();
 
-      // Light mode error color is #ef4444 = rgb(239, 68, 68)
-      expect(controller.element.style.background).toBe('rgb(239, 68, 68)');
+      expect(controller.element.style.background).toBe('rgba(239, 68, 68, 0.2)');
     });
 
     it('setNormal resets button to initial state with clipboard icon', async () => {
@@ -903,7 +923,7 @@ describe('FloatingButton component', () => {
       expect(controller.element.style.background).toBe(initialBg);
     });
 
-    it('glass style loading/success/error states use opaque colors', async () => {
+    it('glass style loading/success/error states use translucent tinted backgrounds', async () => {
       chrome.storage.sync.get = vi.fn((keys, callback) => {
         callback({
           floatingButtonSize: 'medium',
@@ -917,13 +937,13 @@ describe('FloatingButton component', () => {
       const controller = await createFloatingButton({ onClick });
 
       controller.setLoading();
-      expect(controller.element.style.background).toBe('rgb(245, 158, 11)');
+      expect(controller.element.style.background).toBe('rgba(245, 158, 11, 0.2)');
 
       controller.setSuccess();
-      expect(controller.element.style.background).toBe('rgb(34, 197, 94)');
+      expect(controller.element.style.background).toBe('rgba(34, 197, 94, 0.2)');
 
       controller.setError();
-      expect(controller.element.style.background).toBe('rgb(239, 68, 68)');
+      expect(controller.element.style.background).toBe('rgba(239, 68, 68, 0.2)');
     });
   });
 


### PR DESCRIPTION
## Summary
- keep floating button loading, success, and error backgrounds translucent when glass style is enabled
- apply subtle tint values so status feedback remains clear while preserving the frosted-glass look
- update floating button unit tests to cover glass translucency and solid-style opaque regression expectations

## Test plan
- [x] Run `npm run test:run -- tests/unit/content/components/FloatingButton.test.js`
- [ ] Optional manual spot-check on a supported site (YouTube/HN/X/article)

Made with [Cursor](https://cursor.com)