### PR TITLE
chore: sanitize test fixtures and sample transcript content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Your goal is to transform ExtractMD from a collection of monolithic scripts into
 6. **Feature Branch by Default (With Small-Change Exception):** Unless the user explicitly says otherwise, start feature work on a new branch with a clear conventional name (for example: `feat/<short-kebab-description>`, `fix/<short-kebab-description>`, `refactor/<short-kebab-description>`, `chore/<short-kebab-description>`). For small maintenance updates (for example version bumps, copy/docs-only edits, or minor metadata/config tweaks), a dedicated branch is not required.
 7. **Changelog Discipline (Extension-Only):** Document relevant extension updates in `CHANGELOG.md` (usually under `## [Unreleased]`) as part of feature work. Do not include contribution-process/docs changes (for example templates or `CONTRIBUTING.md`) and do not include website-only updates.
 8. **Unreleased Changelog Consolidation:** Keep `## [Unreleased]` concise by merging iterative updates for the same topic (for example, feature + follow-up fix) into one entry instead of duplicating details across sections.
+9. **Sanitized Test Content:** Always use fictional/synthetic names, handles, quotes, transcripts, and IDs in fixtures, temp samples, and test assertions. Never copy real-world personal or sensitive content into test assets.
 
 ## Project Vision (ExtractMD 2.0)
 

--- a/tests/unit/content/x.test.js
+++ b/tests/unit/content/x.test.js
@@ -55,7 +55,7 @@ describe('X content extractor', () => {
 
   it('finds the primary post container for the current status URL', () => {
     loadFixture('post-basic.html');
-    window.history.pushState({}, '', '/writer_one/status/2010751592346030461');
+    window.history.pushState({}, '', '/writer_one/status/9000000000000000001');
 
     const container = findPrimaryXContainer(document);
     expect(container).toBeTruthy();
@@ -63,7 +63,7 @@ describe('X content extractor', () => {
   });
 
   it('waits for the primary container to appear', async () => {
-    window.history.pushState({}, '', '/writer_one/status/2010751592346030461');
+    window.history.pushState({}, '', '/writer_one/status/9000000000000000001');
 
     const pendingContainer = waitForPrimaryXContainer({ timeoutMs: 200 });
     setTimeout(() => {
@@ -76,7 +76,7 @@ describe('X content extractor', () => {
   });
 
   it('times out when waiting for a primary container', async () => {
-    window.history.pushState({}, '', '/writer_one/status/2010751592346030461');
+    window.history.pushState({}, '', '/writer_one/status/9000000000000000001');
 
     const container = await waitForPrimaryXContainer({ timeoutMs: 30 });
     expect(container).toBeNull();
@@ -84,7 +84,7 @@ describe('X content extractor', () => {
 
   it('extracts metadata and markdown body from a standard post', () => {
     loadFixture('post-basic.html');
-    window.history.pushState({}, '', '/writer_one/status/2010751592346030461');
+    window.history.pushState({}, '', '/writer_one/status/9000000000000000001');
 
     const result = extractXMarkdown({
       xIncludeImages: true,
@@ -97,7 +97,7 @@ describe('X content extractor', () => {
 
     expect(result.title).toBe('Building in public with markdown extraction.');
     expect(result.handle).toBe('@writer_one');
-    expect(result.link).toBe(`${window.location.origin}/writer_one/status/2010751592346030461`);
+    expect(result.link).toBe(`${window.location.origin}/writer_one/status/9000000000000000001`);
     expect(result.markdown).not.toContain('# Building in public with markdown extraction.');
     expect(result.markdown).toContain('**Author:** Writer One (@writer_one)');
     expect(result.markdown).toContain('**Date:** 2026-01-17T12:34:56.000Z');
@@ -107,7 +107,7 @@ describe('X content extractor', () => {
 
   it('extracts rich media placeholders and quoted post markdown', () => {
     loadFixture('post-media-quote.html');
-    window.history.pushState({}, '', '/creator_dev/status/2010751592346030461');
+    window.history.pushState({}, '', '/creator_dev/status/9000000000000000002');
 
     const result = extractXMarkdown({
       xIncludeImages: true,
@@ -125,7 +125,7 @@ describe('X content extractor', () => {
       '![State transitions](https://pbs.twimg.com/media/example-two.jpg)'
     );
     expect(result.markdown).toContain(
-      `- [Video attached on X](${window.location.origin}/creator_dev/status/2010751592346030461)`
+      `- [Video attached on X](${window.location.origin}/creator_dev/status/9000000000000000002)`
     );
     expect(result.markdown).toContain('- [Launch note](https://example.com/launch-note)');
     expect(result.markdown).toContain('> Quoted post by @quoted_author');
@@ -134,7 +134,7 @@ describe('X content extractor', () => {
 
   it('falls back to permalink and poster thumbnail for blob-backed videos', () => {
     loadFixture('post-video-blob.html');
-    window.history.pushState({}, '', '/video_author/status/2032872133513408838');
+    window.history.pushState({}, '', '/video_author/status/9000000000000000004');
 
     const result = extractXMarkdown({
       xIncludeImages: true,
@@ -146,19 +146,19 @@ describe('X content extractor', () => {
     });
 
     expect(result.markdown).toContain(
-      `- [Video attached on X](${window.location.origin}/video_author/status/2032872133513408838)`
+      `- [Video attached on X](${window.location.origin}/video_author/status/9000000000000000004)`
     );
     expect(result.markdown).toContain(
-      'https://pbs.twimg.com/ext_tw_video_thumb/2015389729387139072/pu/img/-qDumgPswjyOOHzS.jpg'
+      'https://pbs.twimg.com/ext_tw_video_thumb/9000000000000000099/pu/img/sample-video-thumb.jpg'
     );
     expect(result.markdown).not.toContain(
-      'blob:https://x.com/ac46159e-411b-4334-b63a-5ef83f856d8e'
+      'blob:https://x.com/00000000-0000-4000-8000-000000000000'
     );
   });
 
   it('extracts long-form article body and title from article routes', () => {
     loadFixture('article-longform.html');
-    window.history.pushState({}, '', '/i/articles/2020202020202020202');
+    window.history.pushState({}, '', '/i/articles/9000000000000000010');
 
     const result = extractXMarkdown({
       xIncludeImages: true,
@@ -183,7 +183,7 @@ describe('X content extractor', () => {
 
   it('honors X content toggles for media, quotes, and URL', () => {
     loadFixture('post-media-quote.html');
-    window.history.pushState({}, '', '/creator_dev/status/2010751592346030461');
+    window.history.pushState({}, '', '/creator_dev/status/9000000000000000002');
 
     const result = extractXMarkdown({
       xIncludeImages: false,
@@ -203,7 +203,7 @@ describe('X content extractor', () => {
 
   it('appends metrics context after metadata when enabled', () => {
     loadFixture('post-basic.html');
-    window.history.pushState({}, '', '/writer_one/status/2010751592346030461');
+    window.history.pushState({}, '', '/writer_one/status/9000000000000000001');
 
     const result = extractXMarkdown({
       xIncludeMetricsContext: true,

--- a/tests/unit/content/youtube.test.js
+++ b/tests/unit/content/youtube.test.js
@@ -92,7 +92,7 @@ describe('YouTube content script logic', () => {
           <timeline-item-view-model>
             <transcript-segment-view-model class="ytwTranscriptSegmentViewModelHost">
               <div class="ytwTranscriptSegmentViewModelTimestamp">0:00</div>
-              <span class="yt-core-attributed-string">Atención a la brutal subida de impuestos</span>
+              <span class="yt-core-attributed-string">Intro segment for a synthetic policy briefing</span>
             </transcript-segment-view-model>
           </timeline-item-view-model>
         </macro-markers-panel-item-view-model>
@@ -100,27 +100,27 @@ describe('YouTube content script logic', () => {
           <timeline-item-view-model>
             <transcript-segment-view-model class="ytwTranscriptSegmentViewModelHost">
               <div class="ytwTranscriptSegmentViewModelTimestamp">0:16</div>
-              <span class="yt-core-attributed-string">El socialista Zorán Mamdani llegó a la alcaldía</span>
+              <span class="yt-core-attributed-string">Next we compare two fictional city planning options</span>
             </transcript-segment-view-model>
           </timeline-item-view-model>
         </macro-markers-panel-item-view-model>
       `;
 
       const result = extractTranscriptText(true);
-      expect(result).toContain('[0:00] Atención a la brutal subida de impuestos');
-      expect(result).toContain('[0:16] El socialista Zorán Mamdani llegó a la alcaldía');
+      expect(result).toContain('[0:00] Intro segment for a synthetic policy briefing');
+      expect(result).toContain('[0:16] Next we compare two fictional city planning options');
     });
 
     it('extracts transcript from the new DOM without timestamps', () => {
       document.body.innerHTML = `
         <transcript-segment-view-model class="ytwTranscriptSegmentViewModelHost">
           <div class="ytwTranscriptSegmentViewModelTimestamp">0:00</div>
-          <span class="yt-core-attributed-string">Atención a la brutal subida de impuestos</span>
+          <span class="yt-core-attributed-string">Intro segment for a synthetic policy briefing</span>
         </transcript-segment-view-model>
       `;
 
       const result = extractTranscriptText(false);
-      expect(result).toBe('Atención a la brutal subida de impuestos');
+      expect(result).toBe('Intro segment for a synthetic policy briefing');
       expect(result).not.toContain('[0:00]');
     });
 

--- a/tests/unit/fixtures/x/article-longform.html
+++ b/tests/unit/fixtures/x/article-longform.html
@@ -13,7 +13,7 @@
             <a href="/longform_author">Longform Author</a>
             <span>@longform_author</span>
           </div>
-          <a href="/longform_author/status/2020202020202020202">
+          <a href="/longform_author/status/9000000000000000005">
             <time datetime="2026-01-20T16:45:00.000Z">Jan 20, 2026</time>
           </a>
         </header>

--- a/tests/unit/fixtures/x/post-basic.html
+++ b/tests/unit/fixtures/x/post-basic.html
@@ -11,7 +11,7 @@
           <a href="/writer_one">Writer One</a>
           <span>@writer_one</span>
         </div>
-        <a href="/writer_one/status/2010751592346030461">
+        <a href="/writer_one/status/9000000000000000001">
           <time datetime="2026-01-17T12:34:56.000Z">Jan 17, 2026</time>
         </a>
         <div data-testid="tweetText">

--- a/tests/unit/fixtures/x/post-media-quote.html
+++ b/tests/unit/fixtures/x/post-media-quote.html
@@ -11,7 +11,7 @@
           <a href="/creator_dev">Creator Dev</a>
           <span>@creator_dev</span>
         </div>
-        <a href="/creator_dev/status/2010751592346030461">
+        <a href="/creator_dev/status/9000000000000000002">
           <time datetime="2026-01-18T08:12:00.000Z">Jan 18, 2026</time>
         </a>
         <div data-testid="tweetText">
@@ -34,7 +34,7 @@
             <a href="/quoted_author">Quoted Author</a>
             <span>@quoted_author</span>
           </div>
-          <a href="/quoted_author/status/2000000000000000000">
+          <a href="/quoted_author/status/9000000000000000003">
             <time datetime="2026-01-10T10:00:00.000Z">Jan 10, 2026</time>
           </a>
           <div data-testid="tweetText">

--- a/tests/unit/fixtures/x/post-video-blob.html
+++ b/tests/unit/fixtures/x/post-video-blob.html
@@ -11,7 +11,7 @@
           <a href="/video_author">Video Author</a>
           <span>@video_author</span>
         </div>
-        <a href="/video_author/status/2032872133513408838">
+        <a href="/video_author/status/9000000000000000004">
           <time datetime="2026-03-14T17:31:00.000Z">Mar 14, 2026</time>
         </a>
         <div data-testid="tweetText">
@@ -20,11 +20,11 @@
         <div data-testid="videoPlayer">
           <video
             aria-label="Embedded video"
-            poster="https://pbs.twimg.com/ext_tw_video_thumb/2015389729387139072/pu/img/-qDumgPswjyOOHzS.jpg"
+            poster="https://pbs.twimg.com/ext_tw_video_thumb/9000000000000000099/pu/img/sample-video-thumb.jpg"
           >
             <source
               type="video/mp4"
-              src="blob:https://x.com/ac46159e-411b-4334-b63a-5ef83f856d8e"
+              src="blob:https://x.com/00000000-0000-4000-8000-000000000000"
             />
           </video>
         </div>


### PR DESCRIPTION
## Summary
- Replace real-world-like sample references in X and YouTube unit test assets with synthetic placeholders.
- Update matching assertions so extraction behavior coverage stays unchanged.
- Add a core directive to `AGENTS.md` requiring sanitized fictional content in test fixtures and sample artifacts.

## Test plan
- [x] `npm run test:run -- tests/unit/content/x.test.js tests/unit/content/youtube.test.js`

Made with [Cursor](https://cursor.com)